### PR TITLE
GH-43 app update notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,9 @@
         "build": "react-scripts build",
         "test": "react-scripts test --testTimeout=10000",
         "test:debug": "react-scripts --inspect test --runInBand --no-cache --testTimeout=100000000",
-        "eject": "react-scripts eject"
+        "eject": "react-scripts eject",
+        "preserve:static": "npm run build",
+        "serve:static": "npx serve ./build  -p 3000" 
     },
     "eslintConfig": {
         "extends": [

--- a/src/App.js
+++ b/src/App.js
@@ -23,9 +23,8 @@ import {
 } from "@mui/material/styles";
 import { initialiseApp } from "./redux/initialise/initialiseActions";
 import SnackNotificationButtons from "./components/SnackNotificationButtons";
-import { DataStore } from "aws-amplify";
-import * as models from "./models";
 import { getWhoami } from "./redux/Selectors";
+import registerServiceWorker from './register-worker'
 
 if (
     (!process.env.REACT_APP_OFFLINE_ONLY ||
@@ -145,6 +144,8 @@ function AppContents(props) {
 
     const theme = useTheme();
     dispatch(setMobileView(!useMediaQuery(theme.breakpoints.up("sm"))));
+    
+    registerServiceWorker(props);
 
     return (
         <React.Fragment>

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
-import * as serviceWorker from "./serviceWorker";
 import { BrowserRouter } from "react-router-dom";
 import ReactNotification from "react-notifications-component";
 import "react-notifications-component/dist/theme.css";
@@ -27,8 +26,3 @@ ReactDOM.render(
     </Provider>,
     document.getElementById("root")
 );
-
-// If you want your app to work offline and load faster, you can change
-// unregister() to register() below. Note this comes with some pitfalls.
-// Learn more about service workers: https://bit.ly/CRA-PWA
-serviceWorker.register();

--- a/src/register-worker.js
+++ b/src/register-worker.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import * as serviceWorker from "./serviceWorker";
+import { IconButton } from "@mui/material";
+import RefreshIcon from '@mui/icons-material/Refresh'
+
+export default function registerServiceWorker(props) {
+  const refreshAction = (key) => (
+    <React.Fragment>
+      <IconButton 
+        onClick={ () => { 
+          window.location.reload(); 
+        }} 
+        aria-label="refresh to update application"> <RefreshIcon /> </IconButton> 
+    </React.Fragment>
+  );
+
+  serviceWorker.register({
+    onUpdate: (registration) => {
+
+      if (registration && registration.waiting) {
+        registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+      }
+          
+      props.enqueueSnackbar('Updates Available', {
+        action: refreshAction,
+        persist: true,
+        variant: 'info'
+      });
+    }
+  });
+}


### PR DESCRIPTION
When there is an update a snackbar will notify the user. Updating can happen by refreshing the page or clicking the snack bar

In order to test this locally make a change to the application and run

`npm run serve:static`

You should see the following on page load

![update-snackbar](https://user-images.githubusercontent.com/3280158/164070346-907da4d7-4ac4-46fb-b443-f7bc37fe61b0.png)

