### PR TITLE
Selection mode support

### DIFF
--- a/.github/workflows/aws.yaml
+++ b/.github/workflows/aws.yaml
@@ -29,7 +29,7 @@ jobs:
         CI: false
         GENERATE_SOURCEMAP: false
     - name: NPM test
-      run: npm run test
+      run: npm test -- --silent
     - name: Deploy to S3
       uses: jakejarvis/s3-sync-action@master
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,6 +26,6 @@ jobs:
       run: npm install
 
     - name: Run the tests
-      run: npm test -- --coverage
+      run: npm test -- --coverage --silent
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -27,6 +27,7 @@ function ConfirmationDialog(props) {
                     ) : (
                         <Button
                             data-cy="confirmation-cancel-button"
+                            aria-label="Cancel"
                             onClick={() => {
                                 props.onCancel();
                             }}
@@ -38,6 +39,7 @@ function ConfirmationDialog(props) {
                     {!props.hideOk && (
                         <Button
                             disabled={props.disabled}
+                            aria-label="OK"
                             data-cy="confirmation-ok-button"
                             onClick={() => {
                                 props.onConfirmation();

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -41,6 +41,7 @@ function ConfirmationDialog(props) {
                     )}{" "}
                     {!props.hideOk && (
                         <Button
+                            disabled={props.disabled}
                             data-cy="confirmation-ok-button"
                             onClick={() => {
                                 props.onConfirmation();
@@ -65,6 +66,7 @@ ConfirmationDialog.propTypes = {
     hideCancel: PropTypes.bool,
     hideOk: PropTypes.bool,
     fullScreen: PropTypes.bool,
+    disabled: PropTypes.bool,
 };
 
 ConfirmationDialog.defaultProps = {
@@ -76,6 +78,7 @@ ConfirmationDialog.defaultProps = {
     hideCancel: false,
     hideOk: false,
     fullScreen: false,
+    disabled: false,
 };
 
 export default ConfirmationDialog;

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -13,12 +13,8 @@ function ConfirmationDialog(props) {
             open={props.open}
             fullScreen={props.fullScreen}
             onClose={props.onClose}
-            aria-labelledby="alert-dialog-title"
-            aria-describedby="alert-dialog-description"
         >
-            <DialogTitle id="alert-dialog-title">
-                {props.dialogTitle}
-            </DialogTitle>
+            <DialogTitle>{props.dialogTitle}</DialogTitle>
             <DialogContent>{props.children}</DialogContent>
             <DialogActions>
                 <Stack

--- a/src/components/CoordinatorPicker.js
+++ b/src/components/CoordinatorPicker.js
@@ -54,7 +54,6 @@ function CoordinatorPicker(props) {
     return (
         <div>
             <Autocomplete
-                disablePortal
                 fullWidth
                 key={reset}
                 filterOptions={filterOptions}

--- a/src/components/FavouriteLocationsSelect.js
+++ b/src/components/FavouriteLocationsSelect.js
@@ -32,7 +32,6 @@ function FavouriteLocationsSelect(props) {
 
     return (
         <Autocomplete
-            disablePortal
             fullWidth
             aria-label={props.label}
             filterOptions={filterOptions}

--- a/src/components/IncreaseDecreaseCounter.js
+++ b/src/components/IncreaseDecreaseCounter.js
@@ -22,8 +22,6 @@ function IncreaseDecreaseCounter(props) {
     }));
     const classes = useStyles();
 
-    //console.log(props.disabled);
-
     return (
         <Grid
             container

--- a/src/components/LoadingSpinner.js
+++ b/src/components/LoadingSpinner.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Box } from "@mui/system";
 import React, { useEffect, useRef, useState } from "react";
 
-function LoadingSpinner({ progress, tooltip, size, delay }) {
+function LoadingSpinner({ progress, tooltip, size, delay, ...props }) {
     const [loadingColor, setLoadingColor] = useState(null);
     const [completed, setCompleted] = useState(true);
     const [fade, setFade] = useState(false);
@@ -56,34 +56,36 @@ function LoadingSpinner({ progress, tooltip, size, delay }) {
         return null;
     } else {
         return (
-            <Fade in={fade} unmountOnExit>
-                <Tooltip title={tooltip}>
-                    <Box sx={{ display: "grid" }}>
-                        <CircularProgress
-                            size={size}
-                            variant="determinate"
-                            value={progress}
-                            sx={{
-                                zIndex: 2,
-                                gridColumn: 1,
-                                gridRow: 1,
-                                color: loadingColor,
-                            }}
-                        />
-                        {Math.round(progress) !== 100 && (
+            <Box sx={props.sx}>
+                <Fade in={fade} unmountOnExit>
+                    <Tooltip title={tooltip}>
+                        <Box sx={{ display: "grid" }}>
                             <CircularProgress
                                 size={size}
+                                variant="determinate"
+                                value={progress}
                                 sx={{
+                                    zIndex: 2,
                                     gridColumn: 1,
                                     gridRow: 1,
-                                    opacity: 0.5,
-                                    zIndex: 1,
+                                    color: loadingColor,
                                 }}
                             />
-                        )}
-                    </Box>
-                </Tooltip>
-            </Fade>
+                            {Math.round(progress) !== 100 && (
+                                <CircularProgress
+                                    size={size}
+                                    sx={{
+                                        gridColumn: 1,
+                                        gridRow: 1,
+                                        opacity: 0.5,
+                                        zIndex: 1,
+                                    }}
+                                />
+                            )}
+                        </Box>
+                    </Tooltip>
+                </Fade>
+            </Box>
         );
     }
 }
@@ -93,12 +95,14 @@ LoadingSpinner.propTypes = {
     tooltip: PropTypes.string,
     size: PropTypes.number,
     delay: PropTypes.number,
+    sx: PropTypes.object,
 };
 
 LoadingSpinner.defaultProps = {
     tooltip: "",
     size: 40,
     delay: 0,
+    sx: {},
 };
 
 export default LoadingSpinner;

--- a/src/components/LoadingSpinner.js
+++ b/src/components/LoadingSpinner.js
@@ -32,10 +32,6 @@ function LoadingSpinner({ progress, tooltip, size, delay, error, ...props }) {
     }, [progress, error]);
 
     useEffect(() => {
-        console.log(fade, completed);
-    }, [fade, completed]);
-
-    useEffect(() => {
         if (!error) {
             setLoadingColor(null);
         }

--- a/src/components/LoadingSpinner.js
+++ b/src/components/LoadingSpinner.js
@@ -1,0 +1,80 @@
+import { CircularProgress, Fade, Tooltip } from "@mui/material";
+import PropTypes from "prop-types";
+import { Box } from "@mui/system";
+import React, { useEffect, useRef, useState } from "react";
+
+function LoadingSpinner({ progress, tooltip, size, delay }) {
+    const [loadingColor, setLoadingColor] = useState("orange");
+    const [completed, setCompleted] = useState(true);
+    const timeOut = useRef(null);
+
+    useEffect(() => {
+        if (Math.round(progress) === 100) {
+            setLoadingColor("lightgreen");
+            setTimeout(() => setCompleted(true), 2000);
+            return;
+        } else if (timeOut.current) {
+            clearTimeout(timeOut.current);
+        }
+        if (progress !== null) {
+            setCompleted(false);
+        }
+    }, [progress]);
+
+    if (completed) {
+        return null;
+    } else {
+        return (
+            <Fade
+                in={!completed}
+                style={{
+                    //transitionDelay: query === "progress" ? "800ms" : "0ms",
+                    transitionDelay: delay,
+                }}
+                unmountOnExit
+            >
+                <Tooltip title={tooltip}>
+                    <Box sx={{ display: "grid" }}>
+                        <CircularProgress
+                            size={size}
+                            variant="determinate"
+                            value={progress}
+                            sx={{
+                                zIndex: 2,
+                                gridColumn: 1,
+                                gridRow: 1,
+                                color: loadingColor,
+                            }}
+                        />
+                        {Math.round(progress) !== 100 && (
+                            <CircularProgress
+                                size={size}
+                                sx={{
+                                    gridColumn: 1,
+                                    gridRow: 1,
+                                    opacity: 0.5,
+                                    zIndex: 1,
+                                }}
+                            />
+                        )}
+                    </Box>
+                </Tooltip>
+            </Fade>
+        );
+    }
+}
+
+LoadingSpinner.propTypes = {
+    progress: PropTypes.number.isRequired,
+    tooltip: PropTypes.string,
+    size: PropTypes.number,
+    delay: PropTypes.number,
+};
+
+LoadingSpinner.defaultProps = {
+    tooltip: "",
+    size: 40,
+    delay: 0,
+};
+
+export default LoadingSpinner;

--- a/src/components/LoadingSpinner.js
+++ b/src/components/LoadingSpinner.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Box } from "@mui/system";
 import React, { useEffect, useRef, useState } from "react";
 
-function LoadingSpinner({ progress, tooltip, size, delay, ...props }) {
+function LoadingSpinner({ progress, tooltip, size, delay, error, ...props }) {
     const [loadingColor, setLoadingColor] = useState(null);
     const [completed, setCompleted] = useState(true);
     const [fade, setFade] = useState(false);
@@ -11,7 +11,7 @@ function LoadingSpinner({ progress, tooltip, size, delay, ...props }) {
     const timeOut = useRef(null);
 
     useEffect(() => {
-        if (Math.round(progress) === 100) {
+        if (!error && Math.round(progress) === 100) {
             setLoadingColor("lightgreen");
             setTimeout(() => {
                 setCompleted(true);
@@ -22,13 +22,27 @@ function LoadingSpinner({ progress, tooltip, size, delay, ...props }) {
         } else if (timeOut.current) {
             clearTimeout(timeOut.current);
         }
-        if (progress !== null) {
+        if (!error && progress !== null) {
             setCompleted(false);
             setLoadingColor("orange");
+        } else if (error) {
+            setCompleted(false);
+            setLoadingColor("red");
         }
-    }, [progress]);
+    }, [progress, error]);
 
     useEffect(() => {
+        console.log(fade, completed);
+    }, [fade, completed]);
+
+    useEffect(() => {
+        if (!error) {
+            setLoadingColor(null);
+        }
+    }, [error]);
+
+    useEffect(() => {
+        if (error) return;
         if (delay === 0) {
             setFade(true);
             return;
@@ -38,26 +52,32 @@ function LoadingSpinner({ progress, tooltip, size, delay, ...props }) {
         } else {
             clearTimeout(delayTimer.current);
         }
-    }, [loadingColor, delay]);
+    }, [loadingColor, delay, error]);
 
     useEffect(() => {
+        if (error) return;
         if (delay === 0) return;
-        if (Math.round(progress) === 100 && fade === true) {
+        if (Math.round(progress) === 100 && fade) {
             clearTimeout(delayTimer.current);
         }
-    }, [progress, fade, delay]);
+    }, [progress, fade, delay, error]);
 
     useEffect(() => {
+        if (error) return;
         if (delay === 0) return;
         if (completed) setFade(false);
-    }, [completed, delay]);
+    }, [completed, delay, error]);
 
     if (completed) {
         return null;
     } else {
         return (
             <Box sx={props.sx}>
-                <Fade in={fade} unmountOnExit>
+                <Fade
+                    data-testId="progressive-loading-spinner"
+                    in={error || fade}
+                    unmountOnExit
+                >
                     <Tooltip title={tooltip}>
                         <Box sx={{ display: "grid" }}>
                             <CircularProgress

--- a/src/components/LoadingSpinner.js
+++ b/src/components/LoadingSpinner.js
@@ -4,35 +4,59 @@ import { Box } from "@mui/system";
 import React, { useEffect, useRef, useState } from "react";
 
 function LoadingSpinner({ progress, tooltip, size, delay }) {
-    const [loadingColor, setLoadingColor] = useState("orange");
+    const [loadingColor, setLoadingColor] = useState(null);
     const [completed, setCompleted] = useState(true);
+    const [fade, setFade] = useState(false);
+    const delayTimer = useRef(null);
     const timeOut = useRef(null);
 
     useEffect(() => {
         if (Math.round(progress) === 100) {
             setLoadingColor("lightgreen");
-            setTimeout(() => setCompleted(true), 2000);
+            setTimeout(() => {
+                setCompleted(true);
+                setLoadingColor(null);
+            }, 2000);
+
             return;
         } else if (timeOut.current) {
             clearTimeout(timeOut.current);
         }
         if (progress !== null) {
             setCompleted(false);
+            setLoadingColor("orange");
         }
     }, [progress]);
+
+    useEffect(() => {
+        if (delay === 0) {
+            setFade(true);
+            return;
+        }
+        if (loadingColor === "orange") {
+            delayTimer.current = setTimeout(() => setFade(true), delay);
+        } else {
+            clearTimeout(delayTimer.current);
+        }
+    }, [loadingColor, delay]);
+
+    useEffect(() => {
+        if (delay === 0) return;
+        if (Math.round(progress) === 100 && fade === true) {
+            clearTimeout(delayTimer.current);
+        }
+    }, [progress, fade, delay]);
+
+    useEffect(() => {
+        if (delay === 0) return;
+        if (completed) setFade(false);
+    }, [completed, delay]);
 
     if (completed) {
         return null;
     } else {
         return (
-            <Fade
-                in={!completed}
-                style={{
-                    //transitionDelay: query === "progress" ? "800ms" : "0ms",
-                    transitionDelay: delay,
-                }}
-                unmountOnExit
-            >
+            <Fade in={fade} unmountOnExit>
                 <Tooltip title={tooltip}>
                     <Box sx={{ display: "grid" }}>
                         <CircularProgress

--- a/src/components/RiderPicker.js
+++ b/src/components/RiderPicker.js
@@ -56,7 +56,6 @@ function RiderPicker(props) {
     return (
         <>
             <Autocomplete
-                disablePortal
                 fullWidth
                 key={reset}
                 filterOptions={filterOptions}

--- a/src/components/TaskFilterTextfield.js
+++ b/src/components/TaskFilterTextfield.js
@@ -46,6 +46,9 @@ function TaskFilterTextField(props) {
                 onPressEscape={() => dispatch(clearDashboardFilter())}
                 color={"secondary"}
                 className={classes.root}
+                inputProps={{
+                    "aria-label": "Filter tasks",
+                }}
                 InputProps={{
                     startAdornment: (
                         <InputAdornment position="start">

--- a/src/navigation/Components/SyncStatusCircleLoader.js
+++ b/src/navigation/Components/SyncStatusCircleLoader.js
@@ -1,18 +1,14 @@
 import React, { useEffect } from "react";
-import Tooltip from "@mui/material/Tooltip";
-import CircularProgress from "@mui/material/CircularProgress";
 import { useSelector } from "react-redux";
 import {
     dataStoreModelSyncedStatusSelector,
     networkStatusSelector,
 } from "../../redux/Selectors";
-import { Box } from "@mui/material";
+import LoadingSpinner from "../../components/LoadingSpinner";
 
 function SyncStatusCircleLoader() {
     const modelSyncStatus = useSelector(dataStoreModelSyncedStatusSelector);
-    const [progress, setProgress] = React.useState(0);
-    const [completed, setCompleted] = React.useState(false);
-    const [loadingColor, setLoadingColor] = React.useState("orange");
+    const [progress, setProgress] = React.useState(null);
     const [tooltip, setTooltip] = React.useState("Syncing data...");
     const dataStoreNetworkStatus = useSelector(networkStatusSelector);
 
@@ -27,43 +23,14 @@ function SyncStatusCircleLoader() {
 
     useEffect(() => {
         if (Math.round(progress) === 100) {
-            setLoadingColor("lightgreen");
             setTooltip("Data synced successfully");
-            setTimeout(() => setCompleted(true), 2000);
         }
     }, [progress]);
 
-    if (completed || !dataStoreNetworkStatus) {
+    if (!dataStoreNetworkStatus) {
         return <></>;
     } else {
-        return (
-            <Tooltip title={tooltip}>
-                <Box sx={{ display: "grid" }}>
-                    <CircularProgress
-                        size={40}
-                        variant="determinate"
-                        value={progress}
-                        sx={{
-                            zIndex: 2,
-                            gridColumn: 1,
-                            gridRow: 1,
-                            color: loadingColor,
-                        }}
-                    />
-                    {Math.round(progress) !== 100 && (
-                        <CircularProgress
-                            size={40}
-                            sx={{
-                                gridColumn: 1,
-                                gridRow: 1,
-                                opacity: 0.5,
-                                zIndex: 1,
-                            }}
-                        />
-                    )}
-                </Box>
-            </Tooltip>
-        );
+        return <LoadingSpinner progress={progress} tooltip={tooltip} />;
     }
 }
 

--- a/src/navigation/MainWindow.js
+++ b/src/navigation/MainWindow.js
@@ -29,7 +29,7 @@ function MainWindowContainer(props) {
     const styles = makeStyles((theme) => ({
         root: {
             marginRight:
-                guidedSetupOpen && navIndex === "dashboard" ? "400px" : "auto",
+                guidedSetupOpen && navIndex === "dashboard" ? 0 : "auto",
             marginLeft: navIndex === "dashboard" ? 0 : 200,
             paddingTop: 10,
             paddingBottom: 10,

--- a/src/redux/Reducers.js
+++ b/src/redux/Reducers.js
@@ -26,6 +26,7 @@ import { taskAssigneesReducer } from "./taskAssignees/taskAssigneesReducers";
 import {
     selectionModeReducer,
     selectionModeAvailableItemsReducer,
+    selectionActionsPendingReducer,
 } from "./selectionMode/selectionModeReducers";
 
 const darkModeInitialState = getDarkModePreference();
@@ -303,6 +304,7 @@ const appReducer = combineReducers({
     taskAssigneesReducer,
     selectionModeReducer,
     selectionModeAvailableItemsReducer,
+    selectionActionsPendingReducer,
 });
 
 const rootReducer = (state, action) => {

--- a/src/redux/Selectors.js
+++ b/src/redux/Selectors.js
@@ -33,3 +33,5 @@ export const dataStoreModelSyncedStatusSelector = (state) =>
 export const selectedItemsSelector = (state) => state.selectionModeReducer;
 export const availableSelectionItemsSelector = (state) =>
     state.selectionModeAvailableItemsReducer;
+export const selectionActionsPendingSelector = (state) =>
+    state.selectionActionsPendingReducer;

--- a/src/redux/selectionMode/selectionModeActions.js
+++ b/src/redux/selectionMode/selectionModeActions.js
@@ -83,3 +83,12 @@ export function clearAvailableItems() {
         type: CLEAR_AVAILABLE_ITEMS,
     };
 }
+
+export const SET_SELECTION_ACTIONS_PENDING = "SET_SELECTION_ACTIONS_PENDING";
+
+export function setSelectionActionsPending(pending) {
+    return {
+        type: SET_SELECTION_ACTIONS_PENDING,
+        pending,
+    };
+}

--- a/src/redux/selectionMode/selectionModeActions.js
+++ b/src/redux/selectionMode/selectionModeActions.js
@@ -1,8 +1,9 @@
 export const SELECTION_MODE = "SELECTION_MODE";
 export const SELECT_ITEM = "SELECT_ITEM";
 export const UNSELECT_ITEM = "UNSELECT_ITEM";
+export const SELECT_MULTIPLE_ITEMS = "SELECT_MULTIPLE_ITEMS";
+export const UNSELECT_MULTIPLE_ITEMS = "UNSELECT_MULTIPLE_ITEMS";
 export const SET_SELECTED_ITEMS = "SET_SELECTED_ITEMS";
-export const UNSELECT_ITEMS = "UNSELECT_ITEMS";
 export const CLEAR_ITEMS = "CLEAR_ITEMS";
 export const SELECT_ALL_ITEMS = "SELECT_ALL_ITEMS";
 export const UNSELECT_ALL_ITEMS = "UNSELECT_ALL_ITEMS";
@@ -31,6 +32,22 @@ export function unselectItem(itemId, tabIndex) {
     return {
         type: UNSELECT_ITEM,
         itemId,
+        tabIndex,
+    };
+}
+
+export function selectMultipleItems(items, tabIndex) {
+    return {
+        type: SELECT_MULTIPLE_ITEMS,
+        items,
+        tabIndex,
+    };
+}
+
+export function unselectMultipleItems(itemIds, tabIndex) {
+    return {
+        type: UNSELECT_MULTIPLE_ITEMS,
+        itemIds,
         tabIndex,
     };
 }

--- a/src/redux/selectionMode/selectionModeReducers.js
+++ b/src/redux/selectionMode/selectionModeReducers.js
@@ -21,6 +21,22 @@ export function selectionModeReducer(state = [], action) {
                     action.itemId
                 ),
             };
+        case actions.SELECT_MULTIPLE_ITEMS:
+            return {
+                ...state,
+                [action.tabIndex]: {
+                    ...state[action.tabIndex],
+                    ...action.items,
+                },
+            };
+        case actions.UNSELECT_MULTIPLE_ITEMS:
+            return {
+                ...state,
+                [action.tabIndex]: _.omit(
+                    state[action.tabIndex],
+                    ...action.itemIds
+                ),
+            };
         case actions.CLEAR_ITEMS:
             return { ...state, [action.tabIndex]: {} };
         default:

--- a/src/redux/selectionMode/selectionModeReducers.js
+++ b/src/redux/selectionMode/selectionModeReducers.js
@@ -42,3 +42,12 @@ export function selectionModeAvailableItemsReducer(state = {}, action) {
             return state;
     }
 }
+
+export function selectionActionsPendingReducer(state = false, action) {
+    switch (action.type) {
+        case actions.SET_SELECTION_ACTIONS_PENDING:
+            return action.pending;
+        default:
+            return state;
+    }
+}

--- a/src/scenes/Dashboard/Dashboard.js
+++ b/src/scenes/Dashboard/Dashboard.js
@@ -21,7 +21,7 @@ import {
 } from "../../redux/Selectors";
 import { tasksStatus, userRoles } from "../../apiConsts";
 import { clearDashboardFilter } from "../../redux/dashboardFilter/DashboardFilterActions";
-import { Fab, Hidden } from "@mui/material";
+import { Divider, Fab, Hidden, Stack } from "@mui/material";
 import ActiveRidersChips from "./components/ActiveRidersChips";
 import GuidedSetupDrawer from "./components/GuidedSetupDrawer";
 import MultipleSelectionActionsMenu from "./components/MultipleSelectionActionsMenu";
@@ -98,15 +98,15 @@ function Dashboard() {
     useEffect(setInitialRoleView, [whoami]);
 
     return (
-        <>
-            <Paper sx={{ marginBottom: 10, maxWidth: 1480 }}>
-                <Hidden mdUp>
-                    <DashboardDetailTabs />
-                </Hidden>
-                <MultipleSelectionActionsMenu />
-                {[userRoles.coordinator, "ALL"].includes(roleView) && (
-                    <ActiveRidersChips />
-                )}
+        <Stack divider={<Divider />}>
+            <Hidden mdUp>
+                <DashboardDetailTabs />
+            </Hidden>
+            <MultipleSelectionActionsMenu />
+            {[userRoles.coordinator, "ALL"].includes(roleView) && (
+                <ActiveRidersChips />
+            )}
+            <Paper sx={{ marginBottom: 10 }}>
                 <TasksGrid
                     modalView={"edit"}
                     hideRelayIcons={roleView === userRoles.rider}
@@ -139,7 +139,7 @@ function Dashboard() {
                 )}
             </Hidden>
             <GuidedSetupDrawer />
-        </>
+        </Stack>
     );
 }
 

--- a/src/scenes/Dashboard/Dashboard.js
+++ b/src/scenes/Dashboard/Dashboard.js
@@ -17,6 +17,7 @@ import {
     getRoleView,
     getWhoami,
     guidedSetupOpenSelector,
+    selectedItemsSelector,
 } from "../../redux/Selectors";
 import { tasksStatus, userRoles } from "../../apiConsts";
 import { clearDashboardFilter } from "../../redux/dashboardFilter/DashboardFilterActions";
@@ -24,12 +25,16 @@ import { Fab, Hidden } from "@mui/material";
 import ActiveRidersChips from "./components/ActiveRidersChips";
 import GuidedSetupDrawer from "./components/GuidedSetupDrawer";
 import MultipleSelectionActionsMenu from "./components/MultipleSelectionActionsMenu";
+import _ from "lodash";
 
 function AddClearFab() {
     const dispatch = useDispatch();
     const dashboardFilteredUser = useSelector(dashboardFilteredUserSelector);
     const dashboardFilter = useSelector(dashboardFilterTermSelector);
     const guidedSetupOpen = useSelector(guidedSetupOpenSelector);
+    const selectedItems = useSelector(selectedItemsSelector);
+    const tabIndex = useSelector(dashboardTabIndexSelector);
+    const items = selectedItems[tabIndex];
     const filterOn = !!dashboardFilter || !!dashboardFilteredUser;
     const message = filterOn ? "Clear search" : "Create new";
 
@@ -44,7 +49,16 @@ function AddClearFab() {
 
     return (
         <Fab
-            sx={{ position: "fixed", zIndex: 100, bottom: 30, right: 30 }}
+            sx={{
+                display: {
+                    xs: _.isEmpty(items) ? "block" : "none",
+                    sm: "block",
+                },
+                position: "fixed",
+                zIndex: 100,
+                bottom: 30,
+                right: 30,
+            }}
             color={filterOn ? "secondary" : "primary"}
             variant="extended"
             disabled={guidedSetupOpen}

--- a/src/scenes/Dashboard/components/ActiveRidersChips.js
+++ b/src/scenes/Dashboard/components/ActiveRidersChips.js
@@ -28,7 +28,6 @@ import { displayErrorNotification } from "../../../redux/notifications/Notificat
 import { setDashboardFilteredUser } from "../../../redux/Actions";
 import moment from "moment";
 
-// use for transparency on arrows sometime
 const useStyles = makeStyles((theme) => ({
     gradientContainer: {
         position: "relative",
@@ -37,10 +36,7 @@ const useStyles = makeStyles((theme) => ({
         alignItems: "center",
     },
     gradientLeft: () => {
-        const background =
-            theme.palette.mode === "dark"
-                ? "linear-gradient(90deg, rgba(51,51,51,1) 0%, rgba(0,0,0,0) 100%)"
-                : `linear-gradient(90deg, ${theme.palette.background.paper} 0%, rgba(0,0,0,0) 100%)`;
+        const background = `linear-gradient(90deg, ${theme.palette.background.paper} 0%, rgba(0,0,0,0) 100%)`;
         return {
             background: background,
             width: 35,
@@ -50,10 +46,7 @@ const useStyles = makeStyles((theme) => ({
         };
     },
     gradientRight: () => {
-        const background =
-            theme.palette.mode === "dark"
-                ? "linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(51,51,51,1) 100%)"
-                : `linear-gradient(90deg, rgba(0,0,0,0) 0%, ${theme.palette.background.paper} 100%)`;
+        const background = `linear-gradient(90deg, rgba(0,0,0,0) 0%, ${theme.palette.background.paper} 100%)`;
         return {
             background: background,
             width: 35,

--- a/src/scenes/Dashboard/components/ActiveRidersChips.js
+++ b/src/scenes/Dashboard/components/ActiveRidersChips.js
@@ -187,6 +187,7 @@ function ActiveRidersChips() {
     const roleView = useSelector(getRoleView);
     const dashboardFilteredUserRef = useRef(null);
     dashboardFilteredUserRef.current = dashboardFilteredUser;
+    const theme = useTheme();
 
     const dispatch = useDispatch();
 
@@ -295,7 +296,7 @@ function ActiveRidersChips() {
         return <Typography>Sorry, something went wrong.</Typography>;
     }
     return (
-        <React.Fragment>
+        <Box sx={{ background: theme.palette.background.paper }}>
             <ScrollMenu
                 alignItems="center"
                 LeftArrow={
@@ -352,7 +353,7 @@ function ActiveRidersChips() {
                     );
                 })}
             </ScrollMenu>
-        </React.Fragment>
+        </Box>
     );
 }
 

--- a/src/scenes/Dashboard/components/DashboardDetailTabs.js
+++ b/src/scenes/Dashboard/components/DashboardDetailTabs.js
@@ -56,14 +56,6 @@ TabPanel.propTypes = {
     value: PropTypes.any.isRequired,
 };
 
-function a11yProps(index) {
-    return {
-        "aria-controls": `dashboard-tabpanel-${index}`,
-        "data-cy": `dashboard-tabpanel-${index}`,
-        "aria-labelledby": `dashboard-tabpanel-${index}`,
-    };
-}
-
 export function DashboardDetailTabs(props) {
     const dispatch = useDispatch();
     const [anchorElRoleMenu, setAnchorElRoleMenu] = React.useState(null);
@@ -75,35 +67,30 @@ export function DashboardDetailTabs(props) {
     const guidedSetupOpen = useSelector(guidedSetupOpenSelector);
 
     const theme = useTheme();
-    const isXs = useMediaQuery(theme.breakpoints.down("sm"));
+    const isSm = useMediaQuery(theme.breakpoints.down("sm"));
     const dashboardTabIndex = useSelector(dashboardTabIndexSelector);
 
-    const handleChange = (event, newValue) => {
+    const handleChange = (newValue) => {
         //props.onChange(event, newValue);
         dispatch(setDashboardTabIndex(newValue));
     };
-    const tabs = isXs ? (
-        <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
-            <Tabs
-                value={parseInt(dashboardTabIndex)}
-                onChange={handleChange}
-                aria-label={"dashboard-tabs"}
-            >
-                <Tab icon={<ExploreIcon />} {...a11yProps(0)} />
-                <Tab icon={<DoneIcon />} {...a11yProps(1)} />
-            </Tabs>
-        </Box>
-    ) : (
-        <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
-            <Tabs
-                value={parseInt(dashboardTabIndex)}
-                onChange={handleChange}
-                aria-label={"dashboard-tabs"}
-            >
-                <Tab label="In Progress" {...a11yProps(0)} />
-                <Tab label="Completed" {...a11yProps(1)} />
-            </Tabs>
-        </Box>
+    const tabs = (
+        <Stack spacing={isSm ? 1 : 2} direction="row">
+            <Chip
+                aria-label="Dashboard in Progress"
+                sx={{ padding: 1 }}
+                label="IN PROGRESS"
+                color={dashboardTabIndex === 0 ? "primary" : "default"}
+                onClick={() => handleChange(0)}
+            />
+            <Chip
+                aria-label="Dashboard Completed"
+                sx={{ padding: 1 }}
+                onClick={() => handleChange(1)}
+                color={dashboardTabIndex === 1 ? "primary" : "default"}
+                label="COMPLETED"
+            />
+        </Stack>
     );
 
     const addClearButton =
@@ -149,7 +136,7 @@ export function DashboardDetailTabs(props) {
                 direction={"row"}
                 spacing={2}
                 justifyContent={"flex-start"}
-                alignItems={"flex-end"}
+                alignItems={"center"}
             >
                 <Box>{tabs}</Box>
                 <Hidden mdDown>

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
@@ -1,5 +1,6 @@
 import { Box, Divider, Grid, Stack, Typography } from "@mui/material";
 import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
 import * as models from "../../../models";
 import { userRoles } from "../../../apiConsts";
 import CoordinatorPicker from "../../../components/CoordinatorPicker";
@@ -11,7 +12,7 @@ import { useSelector } from "react-redux";
 import { taskAssigneesSelector } from "../../../redux/Selectors";
 import { determineTaskStatus } from "../../../utilities";
 
-function MultipleSelectionActionsAssignUser(props) {
+function MultipleSelectionActionsAssignUser({ selectedItems, onChange }) {
     const [role, setRole] = useState(userRoles.rider);
     const [state, setState] = useState({
         [userRoles.rider]: [],
@@ -35,7 +36,7 @@ function MultipleSelectionActionsAssignUser(props) {
     }
 
     async function generateModels() {
-        const riders = Object.values(props.selectedItems).map((task) => {
+        const riders = Object.values(selectedItems).map((task) => {
             return Object.values(state[userRoles.rider]).map((assignee) => {
                 return new models.TaskAssignee({
                     assignee,
@@ -44,7 +45,7 @@ function MultipleSelectionActionsAssignUser(props) {
                 });
             });
         });
-        const coords = Object.values(props.selectedItems).map((task) => {
+        const coords = Object.values(selectedItems).map((task) => {
             return Object.values(state[userRoles.coordinator]).map(
                 (assignee) =>
                     new models.TaskAssignee({
@@ -65,14 +66,14 @@ function MultipleSelectionActionsAssignUser(props) {
             });
         });
         const newTasks = await Promise.all(
-            Object.values(props.selectedItems).map(async (task) => {
+            Object.values(selectedItems).map(async (task) => {
                 const status = await determineTaskStatus(task, riders.flat());
                 return models.Task.copyOf(task, (updated) => {
                     updated.status = status;
                 });
             })
         );
-        props.onChange([...filtered, ...newTasks]);
+        onChange([...filtered, ...newTasks]);
     }
     useEffect(() => generateModels(), [state]);
 
@@ -142,5 +143,15 @@ function MultipleSelectionActionsAssignUser(props) {
         </Stack>
     );
 }
+
+MultipleSelectionActionsAssignUser.propTypes = {
+    selectedItems: PropTypes.arrayOf(PropTypes.object),
+    onChange: PropTypes.func,
+};
+
+MultipleSelectionActionsAssignUser.defaultProps = {
+    selectedItems: [],
+    onChange: () => {},
+};
 
 export default MultipleSelectionActionsAssignUser;

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
@@ -68,8 +68,17 @@ function MultipleSelectionActionsAssignUser({ selectedItems, onChange }) {
         const newTasks = await Promise.all(
             Object.values(selectedItems).map(async (task) => {
                 const status = await determineTaskStatus(task, riders.flat());
+                let riderResponsibility = null;
+                for (const rider of riders
+                    .flat()
+                    .map((assignment) => assignment.assignee)) {
+                    riderResponsibility = rider.riderResponsibility;
+                }
                 return models.Task.copyOf(task, (updated) => {
                     updated.status = status;
+                    if (riderResponsibility) {
+                        updated.riderResponsibility = riderResponsibility;
+                    }
                 });
             })
         );

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
@@ -11,8 +11,13 @@ import UserRoleSelect from "../../../components/UserRoleSelect";
 import { useSelector } from "react-redux";
 import { taskAssigneesSelector } from "../../../redux/Selectors";
 import { determineTaskStatus } from "../../../utilities";
+import _ from "lodash";
 
-function MultipleSelectionActionsAssignUser({ selectedItems, onChange }) {
+function MultipleSelectionActionsAssignUser({
+    selectedItems,
+    onChange,
+    onReady,
+}) {
     const [role, setRole] = useState(userRoles.rider);
     const [state, setState] = useState({
         [userRoles.rider]: [],
@@ -36,6 +41,13 @@ function MultipleSelectionActionsAssignUser({ selectedItems, onChange }) {
     }
 
     async function generateModels() {
+        onReady(false);
+        if (
+            _.isEmpty(state[userRoles.coordinator]) &&
+            _.isEmpty(state[userRoles.rider])
+        ) {
+            return;
+        }
         const riders = Object.values(selectedItems).map((task) => {
             return Object.values(state[userRoles.rider]).map((assignee) => {
                 return new models.TaskAssignee({
@@ -89,6 +101,7 @@ function MultipleSelectionActionsAssignUser({ selectedItems, onChange }) {
             );
         }
         onChange([...filtered, ...newTasks]);
+        onReady(true);
     }
     useEffect(() => generateModels(), [state]);
 
@@ -176,11 +189,13 @@ function MultipleSelectionActionsAssignUser({ selectedItems, onChange }) {
 MultipleSelectionActionsAssignUser.propTypes = {
     selectedItems: PropTypes.object,
     onChange: PropTypes.func,
+    onReady: PropTypes.func,
 };
 
 MultipleSelectionActionsAssignUser.defaultProps = {
     selectedItems: [],
     onChange: () => {},
+    onReady: () => {},
 };
 
 export default MultipleSelectionActionsAssignUser;

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
@@ -67,7 +67,10 @@ function MultipleSelectionActionsAssignUser({ selectedItems, onChange }) {
         });
         const newTasks = await Promise.all(
             Object.values(selectedItems).map(async (task) => {
-                const status = await determineTaskStatus(task, riders.flat());
+                let status = task.status;
+                if (riders.flat().length > 0) {
+                    status = await determineTaskStatus(task, riders.flat());
+                }
                 let riderResponsibility = null;
                 for (const rider of riders
                     .flat()

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
@@ -105,6 +105,7 @@ function MultipleSelectionActionsAssignUser({ selectedItems, onChange }) {
                             user && (
                                 <Grid key={user.id} item>
                                     <UserChip
+                                        showResponsibility
                                         onDelete={() =>
                                             handleRemoveUser(user.id)
                                         }

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
@@ -1,30 +1,31 @@
 import { Box, Divider, Grid, Stack, Typography } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
-import * as models from "../../../models";
 import { userRoles } from "../../../apiConsts";
 import CoordinatorPicker from "../../../components/CoordinatorPicker";
 import RecentlyAssignedUsers from "../../../components/RecentlyAssignedUsers";
 import RiderPicker from "../../../components/RiderPicker";
 import UserChip from "../../../components/UserChip";
 import UserRoleSelect from "../../../components/UserRoleSelect";
-import { useSelector } from "react-redux";
-import { taskAssigneesSelector } from "../../../redux/Selectors";
-import { determineTaskStatus } from "../../../utilities";
 import _ from "lodash";
 
-function MultipleSelectionActionsAssignUser({
-    selectedItems,
-    onChange,
-    onReady,
-}) {
+function MultipleSelectionActionsAssignUser({ onChange }) {
     const [role, setRole] = useState(userRoles.rider);
     const [state, setState] = useState({
         [userRoles.rider]: [],
         [userRoles.coordinator]: [],
     });
 
-    const assignees = useSelector(taskAssigneesSelector);
+    useEffect(() => {
+        if (
+            _.isEmpty(state[userRoles.coordinator]) &&
+            _.isEmpty(state[userRoles.rider])
+        ) {
+            onChange(null);
+        } else {
+            onChange(state);
+        }
+    }, [state, onChange]);
 
     function onSelect(user) {
         setState((prevState) => ({
@@ -39,71 +40,6 @@ function MultipleSelectionActionsAssignUser({
             [role]: prevState[role].filter((user) => userId !== user.id),
         }));
     }
-
-    async function generateModels() {
-        onReady(false);
-        if (
-            _.isEmpty(state[userRoles.coordinator]) &&
-            _.isEmpty(state[userRoles.rider])
-        ) {
-            return;
-        }
-        const riders = Object.values(selectedItems).map((task) => {
-            return Object.values(state[userRoles.rider]).map((assignee) => {
-                return new models.TaskAssignee({
-                    assignee,
-                    task,
-                    role: userRoles.rider,
-                });
-            });
-        });
-        const coords = Object.values(selectedItems).map((task) => {
-            return Object.values(state[userRoles.coordinator]).map(
-                (assignee) =>
-                    new models.TaskAssignee({
-                        assignee,
-                        task,
-                        role: userRoles.coordinator,
-                    })
-            );
-        });
-        const result = [...riders, ...coords].flat(2);
-        const filtered = result.filter((assignment) => {
-            return !assignees.items.some((assignee) => {
-                return (
-                    assignment.task.id === assignee.task.id &&
-                    assignment.assignee.id === assignee.assignee.id &&
-                    assignment.role === assignee.role
-                );
-            });
-        });
-        let newTasks = [];
-        if (riders.flat().length > 0) {
-            newTasks = await Promise.all(
-                Object.values(selectedItems).map(async (task) => {
-                    const status = await determineTaskStatus(
-                        task,
-                        riders.flat()
-                    );
-                    let riderResponsibility = task.riderResponsibility;
-                    for (const rider of riders
-                        .flat()
-                        .map((assignment) => assignment.assignee)) {
-                        if (rider.riderResponsibility) {
-                            riderResponsibility = rider.riderResponsibility;
-                        }
-                    }
-                    return models.Task.copyOf(task, (updated) => {
-                        updated.status = status;
-                        updated.riderResponsibility = riderResponsibility;
-                    });
-                })
-            );
-        }
-        onChange([...filtered, ...newTasks]);
-        onReady(true);
-    }
-    useEffect(() => generateModels(), [state]);
 
     return (
         <Stack spacing={2} direction="column" divider={<Divider />}>

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
@@ -1,0 +1,142 @@
+import { Box, Divider, Grid, Stack, Typography } from "@mui/material";
+import { DataStore } from "aws-amplify";
+import React, { useEffect, useState } from "react";
+import * as models from "../../../models";
+import { userRoles } from "../../../apiConsts";
+import CoordinatorPicker from "../../../components/CoordinatorPicker";
+import RecentlyAssignedUsers from "../../../components/RecentlyAssignedUsers";
+import RiderPicker from "../../../components/RiderPicker";
+import UserChip from "../../../components/UserChip";
+import UserRoleSelect from "../../../components/UserRoleSelect";
+import { useSelector } from "react-redux";
+import {
+    dashboardTabIndexSelector,
+    selectedItemsSelector,
+    taskAssigneesSelector,
+} from "../../../redux/Selectors";
+
+function MultipleSelectionActionsAssignUser(props) {
+    const [role, setRole] = useState(userRoles.rider);
+    const [state, setState] = useState({
+        [userRoles.rider]: [],
+        [userRoles.coordinator]: [],
+    });
+
+    const assignees = useSelector(taskAssigneesSelector);
+
+    function onSelect(user) {
+        setState((prevState) => ({
+            ...prevState,
+            [role]: [...prevState[role], user],
+        }));
+    }
+
+    function handleRemoveUser(userId) {
+        setState((prevState) => ({
+            ...prevState,
+            [role]: prevState[role].filter((user) => userId !== user.id),
+        }));
+    }
+
+    function generateModels() {
+        const riders = Object.values(props.selectedItems).map((task) => {
+            return Object.values(state[userRoles.rider]).map((assignee) => {
+                return new models.TaskAssignee({
+                    assignee,
+                    task,
+                    role: userRoles.rider,
+                });
+            });
+        });
+        const coords = Object.values(props.selectedItems).map((task) => {
+            return Object.values(state[userRoles.coordinator]).map(
+                (assignee) =>
+                    new models.TaskAssignee({
+                        assignee,
+                        task,
+                        role: userRoles.coordinator,
+                    })
+            );
+        });
+        const result = [...riders, ...coords].flat(2);
+        const filtered = result.filter((assignment) => {
+            return !assignees.items.some((assignee) => {
+                return (
+                    assignment.task.id === assignee.task.id &&
+                    assignment.assignee.id === assignee.assignee.id &&
+                    assignment.role === assignee.role
+                );
+            });
+        });
+        props.onChange(filtered);
+    }
+    useEffect(generateModels, [state]);
+
+    return (
+        <Stack spacing={2} direction="column" divider={<Divider />}>
+            <UserRoleSelect
+                value={[role]}
+                onSelect={(value) => setRole(value)}
+                exclude={Object.values(userRoles).filter(
+                    (value) =>
+                        ![userRoles.rider, userRoles.coordinator].includes(
+                            value
+                        )
+                )}
+            />
+            <Grid container spacing={1} direction={"row"}>
+                {role === userRoles.rider &&
+                    state[userRoles.rider].map((user) => {
+                        return (
+                            user && (
+                                <Grid key={user.id} item>
+                                    <UserChip
+                                        onDelete={() =>
+                                            handleRemoveUser(user.id)
+                                        }
+                                        user={user}
+                                    />
+                                </Grid>
+                            )
+                        );
+                    })}
+                {role === userRoles.coordinator &&
+                    state[userRoles.coordinator].map((user) => {
+                        return (
+                            user && (
+                                <Grid key={user.id} item>
+                                    <UserChip
+                                        onDelete={() =>
+                                            handleRemoveUser(user.id)
+                                        }
+                                        user={user}
+                                    />
+                                </Grid>
+                            )
+                        );
+                    })}
+            </Grid>
+            <RecentlyAssignedUsers
+                onChange={onSelect}
+                role={role}
+                limit={5}
+                exclude={state[role].map((u) => u.id)}
+            />
+            <Box sx={{ maxWidth: 400 }}>
+                {role === userRoles.rider ? (
+                    <RiderPicker
+                        onSelect={onSelect}
+                        exclude={state[userRoles.rider].map((u) => u.id)}
+                    />
+                ) : (
+                    <CoordinatorPicker
+                        onSelect={onSelect}
+                        exclude={state[userRoles.coordinator].map((u) => u.id)}
+                    />
+                )}
+            </Box>
+        </Stack>
+    );
+}
+
+export default MultipleSelectionActionsAssignUser;

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsAssignUser.js
@@ -145,7 +145,7 @@ function MultipleSelectionActionsAssignUser({ selectedItems, onChange }) {
 }
 
 MultipleSelectionActionsAssignUser.propTypes = {
-    selectedItems: PropTypes.arrayOf(PropTypes.object),
+    selectedItems: PropTypes.object,
     onChange: PropTypes.func,
 };
 

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsDialog.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsDialog.js
@@ -73,7 +73,10 @@ const MultipleSelectionActionsDialog = ({
             const generatedModels = await generateMultipleTaskTimeModels(
                 items,
                 getKey(action),
-                saveData.current
+                saveData.current,
+                assignees.items
+                    ? assignees.items.filter((a) => a.role === userRoles.rider)
+                    : []
             );
             onConfirmation(generatedModels);
         }

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsDialog.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsDialog.js
@@ -1,0 +1,156 @@
+import React, { useRef, useState } from "react";
+import PropTypes from "prop-types";
+import { Divider, Paper, Stack, useMediaQuery } from "@mui/material";
+import { useTheme } from "@mui/styles";
+import {
+    actions,
+    dotActions,
+} from "../components/MultipleSelectionActionsMenu";
+import ConfirmationDialog from "../../../components/ConfirmationDialog";
+import MultipleSelectionActionsInformation from "./MultipleSelectionActionsInformation";
+import MultipleSelectionActionsAssignUser from "./MultipleSelectionActionsAssignUser";
+import MultipleSelectionActionsSetTime from "./MultipleSelectionActionsSetTime";
+import { useSelector } from "react-redux";
+import { taskAssigneesSelector } from "../../../redux/Selectors";
+import generateMultipleAssignmentModels from "../utilities/generateMultipleAssignmentModels";
+import { userRoles } from "../../../apiConsts";
+import generateMultipleTaskTimeModels from "../utilities/generateMultipleTaskTimeModels";
+
+const getKey = (action) => {
+    switch (action) {
+        case actions.assignUser:
+            return null;
+        case actions.markPickedUp:
+            return "timePickedUp";
+        case actions.markDelivered:
+            return "timeDroppedOff";
+        case actions.markRiderHome:
+            return "timeRiderHome";
+        case dotActions.markCancelled:
+            return "timeCancelled";
+        case dotActions.markRejected:
+            return "timeRejected";
+        default:
+    }
+};
+
+const MultipleSelectionActionsDialog = ({
+    items,
+    action,
+    onCancel,
+    open,
+    onConfirmation,
+}) => {
+    const [isDisabled, setIsDisabled] = useState(true);
+    const saveData = useRef(null);
+    const assignees = useSelector(taskAssigneesSelector);
+    const isSm = useMediaQuery(useTheme().breakpoints.down("sm"));
+    const sx = {
+        padding: 2,
+        minWidth: { xs: 0, sm: 500 },
+        minHeight: 300,
+    };
+    const timeAction = [
+        actions.markPickedUp,
+        actions.markDelivered,
+        actions.markRiderHome,
+        dotActions.markCancelled,
+        dotActions.markRejected,
+    ].includes(action);
+
+    const handleConfirmation = async () => {
+        if (!saveData.current) return;
+        setIsDisabled(true);
+        if (action === actions.assignUser) {
+            const generatedModels = await generateMultipleAssignmentModels(
+                items,
+                saveData.current[userRoles.coordinator] || [],
+                saveData.current[userRoles.rider] || [],
+                assignees
+            );
+            onConfirmation(generatedModels);
+        } else if (timeAction) {
+            const generatedModels = await generateMultipleTaskTimeModels(
+                items,
+                getKey(action),
+                saveData.current
+            );
+            onConfirmation(generatedModels);
+        }
+
+        setIsDisabled(false);
+    };
+
+    const handleChange = React.useCallback((value) => {
+        if (value) {
+            saveData.current = value;
+            setIsDisabled(false);
+        } else {
+            saveData.current = null;
+            setIsDisabled(true);
+        }
+    }, []);
+
+    if (action === actions.assignUser) {
+        return (
+            <ConfirmationDialog
+                onCancel={onCancel}
+                disabled={isDisabled}
+                open={open}
+                fullScreen={isSm}
+                onConfirmation={handleConfirmation}
+            >
+                <Paper sx={sx}>
+                    <Stack divider={<Divider />} direction="column" spacing={2}>
+                        <MultipleSelectionActionsInformation
+                            selectedItems={items}
+                            action={action}
+                        />
+                        <MultipleSelectionActionsAssignUser
+                            onChange={handleChange}
+                            selectedItems={items}
+                        />
+                    </Stack>
+                </Paper>
+            </ConfirmationDialog>
+        );
+    } else if (timeAction) {
+        return (
+            <ConfirmationDialog
+                onCancel={onCancel}
+                disabled={isDisabled}
+                open={open}
+                fullScreen={isSm}
+                onConfirmation={handleConfirmation}
+            >
+                <Paper sx={sx}>
+                    <Stack divider={<Divider />} direction="column" spacing={2}>
+                        <MultipleSelectionActionsInformation
+                            selectedItems={items}
+                            action={action}
+                        />
+                        <MultipleSelectionActionsSetTime
+                            selectedItems={items}
+                            onChange={handleChange}
+                        />
+                    </Stack>
+                </Paper>
+            </ConfirmationDialog>
+        );
+    }
+    return null;
+};
+
+MultipleSelectionActionsDialog.propTypes = {
+    onChange: PropTypes.func,
+    items: PropTypes.object,
+    action: PropTypes.string,
+};
+
+MultipleSelectionActionsDialog.defaultProps = {
+    onChange: () => {},
+    items: [],
+    action: "",
+};
+
+export default MultipleSelectionActionsDialog;

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsInformation.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsInformation.js
@@ -118,8 +118,8 @@ function MultipleSelectionActionsInformation({ selectedItems, action }) {
                                 >
                                     <TaskCard
                                         priority={item.priority}
-                                        pickUpAddress={item.pickUpAddress}
-                                        dropOffAddress={item.dropOffAddress}
+                                        pickUpLocation={item.pickUpLocation}
+                                        dropOffLocation={item.dropOffLocation}
                                         riderResponsibility={
                                             item.riderResponsibility
                                         }

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsInformation.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsInformation.js
@@ -1,5 +1,17 @@
 import React, { useEffect, useState } from "react";
-import { Typography } from "@mui/material";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import {
+    Typography,
+    Dialog,
+    DialogContent,
+    DialogActions,
+    Grid,
+    Button,
+    Paper,
+    Link,
+} from "@mui/material";
+import TaskCard from "./TaskCardsColoured";
+import { useTheme } from "@mui/styles";
 
 const actions = {
     assignUser: "Assign User",
@@ -13,25 +25,40 @@ const dotActions = {
 };
 
 function humanReadableAction(action) {
-    if (action === actions.assignUser) {
-        return "Assigning a user to";
-    } else if (action === actions.markPickedUp) {
-        return "Marking as picked up on";
+    if (action === actions.markPickedUp) {
+        return "picked up";
     } else if (action === actions.markDelivered) {
-        return "Marking as delivered on";
+        return "delivered";
     } else if (action === actions.markRiderHome) {
-        return "Marking as rider home on";
+        return "rider home";
     } else if (action === dotActions.markCancelled) {
-        return "Marking as cancelled on";
+        return "cancelled";
     } else if (action === dotActions.markRejected) {
-        return "Marking as rejected on";
+        return "rejected";
     }
-
     return action;
 }
 
 function MultipleSelectionActionsInformation({ selectedItems, action }) {
     const [message, setMessage] = useState("");
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const theme = useTheme();
+    const isMd = useMediaQuery(theme.breakpoints.down("md"));
+
+    function generateLink() {
+        const items = Object.values(selectedItems);
+        const plural = items.length > 1 ? "items" : "item";
+        return (
+            <Link
+                sx={{
+                    cursor: "pointer",
+                }}
+                onClick={() => setDialogOpen(true)}
+            >
+                {items.length} {plural}
+            </Link>
+        );
+    }
 
     function generateMessage() {
         const items = Object.values(selectedItems);
@@ -39,15 +66,85 @@ function MultipleSelectionActionsInformation({ selectedItems, action }) {
             setMessage("No items selected");
             return;
         }
-        if (items.length === 1) {
-            setMessage(`${humanReadableAction(action)} ${items.length} item.`);
-            return;
+        if (action === actions.assignUser) {
+            setMessage(
+                <Typography variant="h6">
+                    Assign users to {generateLink()}
+                </Typography>
+            );
+        } else {
+            setMessage(
+                <Typography variant="h6">
+                    Updating {generateLink()} as {humanReadableAction(action)}
+                </Typography>
+            );
         }
-        setMessage(`${humanReadableAction(action)} ${items.length} items`);
     }
     useEffect(generateMessage, [selectedItems, action]);
 
-    return <Typography variant="h6">{message}</Typography>;
+    const itemLength = Object.values(selectedItems).length;
+
+    return (
+        <>
+            <Dialog
+                open={dialogOpen}
+                fullWidth={!isMd}
+                fullScreen={isMd}
+                maxWidth={itemLength > 4 ? "md" : "sm"}
+                onClose={() => setDialogOpen(false)}
+            >
+                <DialogContent>
+                    <Paper sx={{ padding: isMd ? 0 : 1 }}>
+                        <Grid
+                            sx={{ width: "100%", flexGrow: 1 }}
+                            container
+                            justifyContent="flex-start"
+                            direction="row"
+                            spacing={1}
+                        >
+                            {Object.values(selectedItems).map((item) => (
+                                <Grid
+                                    item
+                                    xs={12}
+                                    sm={itemLength > 4 ? 6 : 12}
+                                    md={itemLength > 4 ? 6 : 12}
+                                    key={item.id}
+                                    sx={{
+                                        marginBottom: 0.5,
+                                        minWidth: 300,
+                                        maxWidth: 410,
+                                        width: "100%",
+                                    }}
+                                >
+                                    <TaskCard
+                                        priority={item.priority}
+                                        pickUpAddress={item.pickUpAddress}
+                                        dropOffAddress={item.dropOffAddress}
+                                        riderResponsibility={
+                                            item.riderResponsibility
+                                        }
+                                        timeOfCall={item.timeOfCall}
+                                        status={item.status}
+                                    />
+                                </Grid>
+                            ))}
+                        </Grid>
+                    </Paper>
+                </DialogContent>
+                <DialogActions>
+                    <Button
+                        onClick={() => {
+                            setDialogOpen(false);
+                        }}
+                    >
+                        Close
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            {message}
+        </>
+    );
 }
 
 export default MultipleSelectionActionsInformation;

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsInformation.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsInformation.js
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from "react";
+import { Typography } from "@mui/material";
+
+const actions = {
+    assignUser: "Assign User",
+    markPickedUp: "Picked Up",
+    markDelivered: "Delivered",
+    markRiderHome: "Rider Home",
+};
+const dotActions = {
+    markCancelled: "Cancelled",
+    markRejected: "Rejected",
+};
+
+function humanReadableAction(action) {
+    if (action === actions.assignUser) {
+        return "Assigning a user to";
+    } else if (action === actions.markPickedUp) {
+        return "Marking as picked up on";
+    } else if (action === actions.markDelivered) {
+        return "Marking as delivered on";
+    } else if (action === actions.markRiderHome) {
+        return "Marking as rider home on";
+    } else if (action === dotActions.markCancelled) {
+        return "Marking as cancelled on";
+    } else if (action === dotActions.markRejected) {
+        return "Marking as rejected on";
+    }
+
+    return action;
+}
+
+function MultipleSelectionActionsInformation({ selectedItems, action }) {
+    const [message, setMessage] = useState("");
+
+    function generateMessage() {
+        const items = Object.values(selectedItems);
+        if (items.length === 0) {
+            setMessage("No items selected");
+            return;
+        }
+        if (items.length === 1) {
+            setMessage(`${humanReadableAction(action)} ${items.length} item.`);
+            return;
+        }
+        setMessage(`${humanReadableAction(action)} ${items.length} items`);
+    }
+    useEffect(generateMessage, [selectedItems, action]);
+
+    return <Typography variant="h6">{message}</Typography>;
+}
+
+export default MultipleSelectionActionsInformation;

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -31,6 +31,7 @@ import MultipleSelectionActionsAssignUser from "./MultipleSelectionActionsAssign
 import { DataStore } from "aws-amplify";
 import MultipleSelectionActionsSetTime from "./MultipleSelectionActionsSetTime";
 import MultipleSelectionActionsInformation from "./MultipleSelectionActionsInformation";
+import LoadingSpinner from "../../../components/LoadingSpinner";
 
 const actions = {
     assignUser: "Assign User",
@@ -131,6 +132,7 @@ function MultipleSelectionActionsMenu() {
     const [state, setState] = useState(initialState);
     const selectedItems = selectedItemsAll[tabIndex];
     const [currentAction, setCurrentAction] = useState(null);
+    const [saveProgress, setSaveProgress] = useState(null);
     const saveData = useRef([]);
     const theme = useTheme();
     const isSm = useMediaQuery(theme.breakpoints.down("sm"));
@@ -267,10 +269,18 @@ function MultipleSelectionActionsMenu() {
     }
 
     function saveModels() {
-        return Promise.all(
-            saveData.current.map((model) => DataStore.save(model))
-        );
+        const promises = saveData.current.map((model) => DataStore.save(model));
+        let count = 0;
+        for (const p of promises) {
+            p.then(() => {
+                count++;
+                setSaveProgress((count * 100) / promises.length);
+            });
+        }
+        return Promise.all(promises);
     }
+
+    useEffect(() => console.log(saveProgress), [saveProgress]);
 
     async function handleConfirmation() {
         setCurrentAction(null);
@@ -319,6 +329,7 @@ function MultipleSelectionActionsMenu() {
                         {dotsMenu}
                     </>
                 )}
+                <LoadingSpinner delay={800} progress={saveProgress} />
             </Stack>
             <ConfirmationDialog
                 onCancel={() => setCurrentAction(null)}

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -31,6 +31,7 @@ import ConfirmationDialog from "../../../components/ConfirmationDialog";
 import MultipleSelectionActionsAssignUser from "./MultipleSelectionActionsAssignUser";
 import { DataStore } from "aws-amplify";
 import MultipleSelectionActionsSetTime from "./MultipleSelectionActionsSetTime";
+import MultipleSelectionActionsInformation from "./MultipleSelectionActionsInformation";
 
 const actions = {
     assignUser: "Assign User",
@@ -70,10 +71,16 @@ const DialogActions = ({ onChange, items, action }) => {
     if (action === actions.assignUser) {
         return (
             <Paper sx={{ padding: 2, minWidth: 500, minHeight: 300 }}>
-                <MultipleSelectionActionsAssignUser
-                    onChange={onChange}
-                    selectedItems={items}
-                />
+                <Stack divider={<Divider />} direction="column" spacing={2}>
+                    <MultipleSelectionActionsInformation
+                        selectedItems={items}
+                        action={action}
+                    />
+                    <MultipleSelectionActionsAssignUser
+                        onChange={onChange}
+                        selectedItems={items}
+                    />
+                </Stack>
             </Paper>
         );
     } else if (
@@ -86,11 +93,19 @@ const DialogActions = ({ onChange, items, action }) => {
         ].includes(action)
     ) {
         return (
-            <MultipleSelectionActionsSetTime
-                selectedItems={items}
-                onChange={onChange}
-                timeKey={getKey(action)}
-            />
+            <Paper sx={{ padding: 2 }}>
+                <Stack divider={<Divider />} direction="column" spacing={2}>
+                    <MultipleSelectionActionsInformation
+                        selectedItems={items}
+                        action={action}
+                    />
+                    <MultipleSelectionActionsSetTime
+                        selectedItems={items}
+                        onChange={onChange}
+                        timeKey={getKey(action)}
+                    />
+                </Stack>
+            </Paper>
         );
     }
     return null;
@@ -98,7 +113,7 @@ const DialogActions = ({ onChange, items, action }) => {
 
 DialogActions.propTypes = {
     onChange: PropTypes.func,
-    items: PropTypes.arrayOf(PropTypes.object),
+    items: PropTypes.object,
     action: PropTypes.string,
 };
 

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -25,13 +25,14 @@ import {
     dashboardTabIndexSelector,
     selectedItemsSelector,
 } from "../../../redux/Selectors";
-import { tasksStatus, userRoles } from "../../../apiConsts";
+import { tasksStatus } from "../../../apiConsts";
 import ConfirmationDialog from "../../../components/ConfirmationDialog";
 import MultipleSelectionActionsAssignUser from "./MultipleSelectionActionsAssignUser";
 import { DataStore } from "aws-amplify";
 import MultipleSelectionActionsSetTime from "./MultipleSelectionActionsSetTime";
 import MultipleSelectionActionsInformation from "./MultipleSelectionActionsInformation";
 import LoadingSpinner from "../../../components/LoadingSpinner";
+import _ from "lodash";
 
 const actions = {
     assignUser: "Assign User",
@@ -68,9 +69,14 @@ const initialState = {
 };
 
 const DialogActions = ({ onChange, items, action }) => {
+    const sx = {
+        padding: 2,
+        minWidth: { xs: 0, sm: 500 },
+        minHeight: 300,
+    };
     if (action === actions.assignUser) {
         return (
-            <Paper sx={{ padding: 2, minWidth: 500, minHeight: 300 }}>
+            <Paper sx={sx}>
                 <Stack divider={<Divider />} direction="column" spacing={2}>
                     <MultipleSelectionActionsInformation
                         selectedItems={items}
@@ -93,7 +99,7 @@ const DialogActions = ({ onChange, items, action }) => {
         ].includes(action)
     ) {
         return (
-            <Paper sx={{ padding: 2 }}>
+            <Paper sx={sx}>
                 <Stack divider={<Divider />} direction="column" spacing={2}>
                     <MultipleSelectionActionsInformation
                         selectedItems={items}
@@ -295,54 +301,83 @@ function MultipleSelectionActionsMenu() {
 
     return (
         <>
-            <Stack
-                alignItems="center"
-                divider={<Divider orientation="vertical" flexItem />}
-                spacing={2}
-                direction="row"
+            <Paper
+                sx={{
+                    position: {
+                        xs: "fixed",
+                        sm: "relative",
+                    },
+                    display: {
+                        xs: _.isEmpty(selectedItems) ? "none" : "block",
+                        sm: "block",
+                    },
+                    zIndex: 1000,
+                    borderRadius: 0,
+                    bottom: { xs: 0, sm: "auto" },
+                    width: { xs: "100%", sm: "auto" },
+                }}
             >
-                <ToggleButton
-                    aria-label="Select All"
-                    sx={{ margin: 0.5 }}
-                    size="small"
-                    onClick={handleOnClickCheck}
-                    disabled={!!dashboardFilter}
+                <Stack
+                    sx={{ minHeight: 50 }}
+                    alignItems="center"
+                    divider={
+                        isSm ? null : (
+                            <Divider orientation="vertical" flexItem />
+                        )
+                    }
+                    spacing={2}
+                    direction="row"
                 >
-                    {getCheckBox()}
-                </ToggleButton>
-                {selectedItems && Object.values(selectedItems).length > 0 && (
-                    <>
-                        {Object.values(actions).map((action) => (
-                            <Button
-                                data-testId="select-action-button"
-                                aria-label={`Selection ${action}`}
-                                key={action}
-                                size="small"
-                                onClick={() => {
-                                    handleActionClick(action);
-                                }}
-                                disabled={checkButtonDisabled(action)}
-                            >
-                                {action}
-                            </Button>
-                        ))}
-                        {dotsMenu}
-                    </>
-                )}
-                <LoadingSpinner
-                    sx={{
-                        position: {
-                            xs: "absolute",
-                            sm: "absolute",
-                            md: "relative",
-                        },
-                        left: { xs: 10, sm: 10, md: "auto" },
-                        bottom: { xs: 20, sm: 20, md: "auto" },
-                    }}
-                    delay={1000}
-                    progress={saveProgress}
-                />
-            </Stack>
+                    {!isSm && (
+                        <ToggleButton
+                            aria-label="Select All"
+                            sx={{ margin: 0.5 }}
+                            size="small"
+                            onClick={handleOnClickCheck}
+                            disabled={!!dashboardFilter}
+                        >
+                            {getCheckBox()}
+                        </ToggleButton>
+                    )}
+                    {selectedItems && Object.values(selectedItems).length > 0 && (
+                        <Stack
+                            sx={{ width: "100%" }}
+                            justifyContent={
+                                isSm ? "space-between" : "flex-start"
+                            }
+                            direction="row"
+                        >
+                            {Object.values(actions).map((action) => (
+                                <Button
+                                    data-testId="select-action-button"
+                                    aria-label={`Selection ${action}`}
+                                    key={action}
+                                    size="small"
+                                    onClick={() => {
+                                        handleActionClick(action);
+                                    }}
+                                    disabled={checkButtonDisabled(action)}
+                                >
+                                    {action}
+                                </Button>
+                            ))}
+                            {dotsMenu}
+                        </Stack>
+                    )}
+                    <LoadingSpinner
+                        sx={{
+                            position: {
+                                xs: "absolute",
+                                sm: "relative",
+                            },
+                            left: { xs: 10, sm: "auto" },
+                            bottom: { xs: 20, sm: "auto" },
+                        }}
+                        delay={1000}
+                        progress={saveProgress}
+                    />
+                </Stack>
+            </Paper>
             <ConfirmationDialog
                 onCancel={() => setCurrentAction(null)}
                 open={!!currentAction}

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -329,7 +329,19 @@ function MultipleSelectionActionsMenu() {
                         {dotsMenu}
                     </>
                 )}
-                <LoadingSpinner delay={1000} progress={saveProgress} />
+                <LoadingSpinner
+                    sx={{
+                        position: {
+                            xs: "absolute",
+                            sm: "absolute",
+                            md: "relative",
+                        },
+                        left: { xs: 10, sm: 10, md: "auto" },
+                        bottom: { xs: 20, sm: 20, md: "auto" },
+                    }}
+                    delay={1000}
+                    progress={saveProgress}
+                />
             </Stack>
             <ConfirmationDialog
                 onCancel={() => setCurrentAction(null)}

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -7,6 +7,7 @@ import MenuItem from "@mui/material/MenuItem";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import IndeterminateCheckBoxIcon from "@mui/icons-material/IndeterminateCheckBox";
 import {
+    Box,
     Button,
     Divider,
     IconButton,
@@ -303,7 +304,7 @@ function MultipleSelectionActionsMenu() {
 
     return (
         <>
-            <Paper
+            <Box
                 sx={{
                     position: {
                         xs: "fixed",
@@ -314,9 +315,9 @@ function MultipleSelectionActionsMenu() {
                         sm: "block",
                     },
                     zIndex: 1000,
-                    borderRadius: 0,
                     bottom: { xs: 0, sm: "auto" },
                     width: { xs: "100%", sm: "auto" },
+                    background: theme.palette.background.paper,
                 }}
             >
                 <Stack
@@ -347,6 +348,7 @@ function MultipleSelectionActionsMenu() {
                             justifyContent={
                                 isSm ? "space-between" : "flex-start"
                             }
+                            spacing={isSm ? 0 : 1}
                             direction="row"
                         >
                             {Object.values(buttonActions).map((action) => (
@@ -379,7 +381,7 @@ function MultipleSelectionActionsMenu() {
                         progress={saveProgress}
                     />
                 </Stack>
-            </Paper>
+            </Box>
             <ConfirmationDialog
                 onCancel={() => setCurrentAction(null)}
                 open={!!currentAction}

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -1,14 +1,19 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import * as selectionModeActions from "../../../redux/selectionMode/selectionModeActions";
+import { useTheme } from "@mui/material/styles";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import IndeterminateCheckBoxIcon from "@mui/icons-material/IndeterminateCheckBox";
 import {
     Button,
+    Dialog,
     Divider,
     IconButton,
+    Paper,
     Stack,
     ToggleButton,
+    useMediaQuery,
 } from "@mui/material";
 import CheckBoxIcon from "@mui/icons-material/CheckBox";
 import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
@@ -20,7 +25,10 @@ import {
     dashboardTabIndexSelector,
     selectedItemsSelector,
 } from "../../../redux/Selectors";
-import { tasksStatus } from "../../../apiConsts";
+import { tasksStatus, userRoles } from "../../../apiConsts";
+import ConfirmationDialog from "../../../components/ConfirmationDialog";
+import MultipleSelectionActionsAssignUser from "./MultipleSelectionActionsAssignUser";
+import { DataStore } from "aws-amplify";
 
 const actions = {
     assignUser: "Assign User",
@@ -47,6 +55,10 @@ function MultipleSelectionActionsMenu() {
     const dashboardFilter = useSelector(dashboardFilterTermSelector);
     const [state, setState] = useState(initialState);
     const selectedItems = selectedItemsAll[tabIndex];
+    const [currentAction, setCurrentAction] = useState(null);
+    const saveData = useRef([]);
+    const theme = useTheme();
+    const isSm = useMediaQuery(theme.breakpoints.down("sm"));
 
     const handleClick = (event) => {
         event.preventDefault();
@@ -59,6 +71,7 @@ function MultipleSelectionActionsMenu() {
         e.preventDefault();
         setState(initialState);
     };
+
     function checkButtonDisabled(action) {
         if (!selectedItems) return true;
         const values = Object.values(selectedItems);
@@ -171,41 +184,91 @@ function MultipleSelectionActionsMenu() {
         </>
     );
 
+    function handleActionClick(action) {
+        if (action === actions.assignUser) {
+            setCurrentAction(action);
+        } else if (action === actions.markPickedUp) {
+        } else if (action === actions.markDelivered) {
+        } else if (action === actions.markRiderHome) {
+        } else if (action === actions.markCancelled) {
+        } else if (action === actions.markRejected) {
+        }
+    }
+
+    function saveModels() {
+        return Promise.all(
+            saveData.current.map((model) => DataStore.save(model))
+        );
+    }
+
+    async function handleConfirmation() {
+        await saveModels();
+        for (const i of Object.values(selectedItems)) {
+            dispatch(selectionModeActions.unselectItem(i.id, tabIndex));
+        }
+        setCurrentAction(null);
+    }
+
+    const dialogContents =
+        currentAction === actions.assignUser ? (
+            <Paper sx={{ padding: 2, minWidth: 500, minHeight: 300 }}>
+                <MultipleSelectionActionsAssignUser
+                    selectedItems={selectedItems}
+                    onChange={(items) => {
+                        console.log(items);
+                        saveData.current = items;
+                    }}
+                />
+            </Paper>
+        ) : null;
+
     const dispatch = useDispatch();
     return (
-        <Stack
-            alignItems="center"
-            divider={<Divider orientation="vertical" flexItem />}
-            spacing={2}
-            direction="row"
-        >
-            <ToggleButton
-                aria-label="Select All"
-                sx={{ margin: 0.5 }}
-                size="small"
-                onClick={handleOnClickCheck}
-                disabled={!!dashboardFilter}
+        <>
+            <Stack
+                alignItems="center"
+                divider={<Divider orientation="vertical" flexItem />}
+                spacing={2}
+                direction="row"
             >
-                {getCheckBox()}
-            </ToggleButton>
-            {selectedItems && Object.values(selectedItems).length > 0 && (
-                <>
-                    {Object.values(actions).map((action) => (
-                        <Button
-                            data-testId="select-action-button"
-                            aria-label={`Selection ${action}`}
-                            key={action}
-                            size="small"
-                            onClick={() => {}}
-                            disabled={checkButtonDisabled(action)}
-                        >
-                            {action}
-                        </Button>
-                    ))}
-                    {dotsMenu}
-                </>
-            )}
-        </Stack>
+                <ToggleButton
+                    aria-label="Select All"
+                    sx={{ margin: 0.5 }}
+                    size="small"
+                    onClick={handleOnClickCheck}
+                    disabled={!!dashboardFilter}
+                >
+                    {getCheckBox()}
+                </ToggleButton>
+                {selectedItems && Object.values(selectedItems).length > 0 && (
+                    <>
+                        {Object.values(actions).map((action) => (
+                            <Button
+                                data-testId="select-action-button"
+                                aria-label={`Selection ${action}`}
+                                key={action}
+                                size="small"
+                                onClick={() => {
+                                    handleActionClick(action);
+                                }}
+                                disabled={checkButtonDisabled(action)}
+                            >
+                                {action}
+                            </Button>
+                        ))}
+                        {dotsMenu}
+                    </>
+                )}
+            </Stack>
+            <ConfirmationDialog
+                onCancel={() => setCurrentAction(null)}
+                open={!!currentAction}
+                fullScreen={isSm}
+                onConfirmation={handleConfirmation}
+            >
+                {dialogContents}
+            </ConfirmationDialog>
+        </>
     );
 }
 

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -299,6 +299,8 @@ function MultipleSelectionActionsMenu() {
 
     const dispatch = useDispatch();
 
+    const buttonActions = isSm ? actions : { ...actions, ...dotActions };
+
     return (
         <>
             <Paper
@@ -347,7 +349,7 @@ function MultipleSelectionActionsMenu() {
                             }
                             direction="row"
                         >
-                            {Object.values(actions).map((action) => (
+                            {Object.values(buttonActions).map((action) => (
                                 <Button
                                     data-testId="select-action-button"
                                     aria-label={`Selection ${action}`}
@@ -361,7 +363,7 @@ function MultipleSelectionActionsMenu() {
                                     {action}
                                 </Button>
                             ))}
-                            {dotsMenu}
+                            {isSm && dotsMenu}
                         </Stack>
                     )}
                     <LoadingSpinner

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
 import * as selectionModeActions from "../../../redux/selectionMode/selectionModeActions";
 import { useTheme } from "@mui/material/styles";
 import Menu from "@mui/material/Menu";
@@ -93,6 +94,18 @@ const DialogActions = ({ onChange, items, action }) => {
         );
     }
     return null;
+};
+
+DialogActions.propTypes = {
+    onChange: PropTypes.func,
+    items: PropTypes.arrayOf(PropTypes.object),
+    action: PropTypes.string,
+};
+
+DialogActions.defaultProps = {
+    onChange: () => {},
+    items: [],
+    action: "",
 };
 
 function MultipleSelectionActionsMenu() {

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -69,26 +69,49 @@ const initialState = {
     mouseY: null,
 };
 
-const DialogActions = ({ onChange, items, action }) => {
+const DialogActions = ({
+    onChange,
+    items,
+    action,
+    onCancel,
+    open,
+    onConfirmation,
+}) => {
+    const [isReady, setIsReady] = useState(false);
+    const isSm = useMediaQuery(useTheme().breakpoints.down("sm"));
     const sx = {
         padding: 2,
         minWidth: { xs: 0, sm: 500 },
         minHeight: 300,
     };
+
+    const handleReady = (v) => {
+        console.log(v);
+        setIsReady(v);
+    };
     if (action === actions.assignUser) {
         return (
-            <Paper sx={sx}>
-                <Stack divider={<Divider />} direction="column" spacing={2}>
-                    <MultipleSelectionActionsInformation
-                        selectedItems={items}
-                        action={action}
-                    />
-                    <MultipleSelectionActionsAssignUser
-                        onChange={onChange}
-                        selectedItems={items}
-                    />
-                </Stack>
-            </Paper>
+            <ConfirmationDialog
+                onCancel={onCancel}
+                disabled={!isReady}
+                open={open}
+                fullScreen={isSm}
+                onConfirmation={onConfirmation}
+            >
+                <Paper sx={sx}>
+                    <Stack divider={<Divider />} direction="column" spacing={2}>
+                        <MultipleSelectionActionsInformation
+                            selectedItems={items}
+                            action={action}
+                        />
+                        <MultipleSelectionActionsAssignUser
+                            onReady={handleReady}
+                            onChange={onChange}
+                            selectedItems={items}
+                        />
+                    </Stack>
+                </Paper>
+            </ConfirmationDialog>
         );
     } else if (
         [
@@ -100,19 +123,29 @@ const DialogActions = ({ onChange, items, action }) => {
         ].includes(action)
     ) {
         return (
-            <Paper sx={sx}>
-                <Stack divider={<Divider />} direction="column" spacing={2}>
-                    <MultipleSelectionActionsInformation
-                        selectedItems={items}
-                        action={action}
-                    />
-                    <MultipleSelectionActionsSetTime
-                        selectedItems={items}
-                        onChange={onChange}
-                        timeKey={getKey(action)}
-                    />
-                </Stack>
-            </Paper>
+            <ConfirmationDialog
+                onCancel={onCancel}
+                onReady={(v) => setIsReady(v)}
+                disabled={!isReady}
+                open={open}
+                fullScreen={isSm}
+                onConfirmation={onConfirmation}
+            >
+                <Paper sx={sx}>
+                    <Stack divider={<Divider />} direction="column" spacing={2}>
+                        <MultipleSelectionActionsInformation
+                            selectedItems={items}
+                            action={action}
+                        />
+                        <MultipleSelectionActionsSetTime
+                            selectedItems={items}
+                            onReady={handleReady}
+                            onChange={onChange}
+                            timeKey={getKey(action)}
+                        />
+                    </Stack>
+                </Paper>
+            </ConfirmationDialog>
         );
     }
     return null;
@@ -397,18 +430,14 @@ function MultipleSelectionActionsMenu() {
                     />
                 </Stack>
             </Box>
-            <ConfirmationDialog
+            <DialogActions
                 onCancel={() => setCurrentAction(null)}
-                open={!!currentAction}
-                fullScreen={isSm}
+                open={currentAction !== null}
+                items={selectedItems}
+                action={currentAction}
                 onConfirmation={handleConfirmation}
-            >
-                <DialogActions
-                    items={selectedItems}
-                    action={currentAction}
-                    onChange={(models) => (saveData.current = models)}
-                />
-            </ConfirmationDialog>
+                onChange={(models) => (saveData.current = models)}
+            />
         </>
     );
 }

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -8,7 +8,6 @@ import MoreVertIcon from "@mui/icons-material/MoreVert";
 import IndeterminateCheckBoxIcon from "@mui/icons-material/IndeterminateCheckBox";
 import {
     Button,
-    Dialog,
     Divider,
     IconButton,
     Paper,
@@ -274,9 +273,11 @@ function MultipleSelectionActionsMenu() {
     }
 
     async function handleConfirmation() {
+        setCurrentAction(null);
+        dispatch(selectionActions.setSelectionActionsPending(true));
         await saveModels();
         dispatch(selectionModeActions.clearItems(tabIndex));
-        setCurrentAction(null);
+        dispatch(selectionActions.setSelectionActionsPending(false));
         saveData.current = [];
     }
 

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -203,9 +203,7 @@ function MultipleSelectionActionsMenu() {
 
     async function handleConfirmation() {
         await saveModels();
-        for (const i of Object.values(selectedItems)) {
-            dispatch(selectionModeActions.unselectItem(i.id, tabIndex));
-        }
+        dispatch(selectionModeActions.clearItems(tabIndex));
         setCurrentAction(null);
     }
 

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -341,7 +341,11 @@ function MultipleSelectionActionsMenu() {
                             sx={{ margin: 0.5 }}
                             size="small"
                             onClick={handleOnClickCheck}
-                            disabled={!!dashboardFilter}
+                            disabled={
+                                !!dashboardFilter ||
+                                Object.values(availableSelectionItems)
+                                    .length === 0
+                            }
                         >
                             {getCheckBox()}
                         </ToggleButton>

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -371,7 +371,7 @@ function MultipleSelectionActionsMenu() {
                                 sm: "relative",
                             },
                             left: { xs: 10, sm: "auto" },
-                            bottom: { xs: 20, sm: "auto" },
+                            bottom: { xs: 60, sm: "auto" },
                         }}
                         delay={1000}
                         progress={saveProgress}

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -329,7 +329,7 @@ function MultipleSelectionActionsMenu() {
                         {dotsMenu}
                     </>
                 )}
-                <LoadingSpinner delay={800} progress={saveProgress} />
+                <LoadingSpinner delay={1000} progress={saveProgress} />
             </Stack>
             <ConfirmationDialog
                 onCancel={() => setCurrentAction(null)}

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -257,6 +257,14 @@ function MultipleSelectionActionsMenu() {
                     background: theme.palette.background.paper,
                 }}
             >
+                {isSm && Object.keys(selectedItems).length > 0 && (
+                    <Typography sx={{ margin: 0.5 }} fontWeight="bold">
+                        You have {Object.keys(selectedItems).length} selected{" "}
+                        {Object.keys(selectedItems).length > 1
+                            ? "items"
+                            : "item"}
+                    </Typography>
+                )}
                 <Stack
                     sx={{ minHeight: 50 }}
                     alignItems="center"

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.js
@@ -207,7 +207,6 @@ function MultipleSelectionActionsMenu() {
 
     function handleActionClick(action) {
         setCurrentAction(action);
-        if (dashboardFilteredUser) dispatch(setDashboardFilteredUser(null));
     }
 
     function saveModels(models) {

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
@@ -611,7 +611,7 @@ describe("MultipleSelectionActionsMenu", () => {
             );
         }
         expect(await screen.findAllByTestId("CheckBoxIcon")).toHaveLength(12);
-        expect(screen.getByText(/10 items/)).toBeInTheDocument();
+        expect(screen.getAllByText(/10 items/)).toHaveLength(2);
     });
 
     test("throwing an error on save", async () => {

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
@@ -388,12 +388,16 @@ describe("MultipleSelectionActionsMenu", () => {
         const textBox = screen.getByRole("textbox");
         userEvent.type(textBox, assignee.displayName);
         userEvent.click(screen.getByText(assignee.displayName));
-        await waitFor(() => {
-            expect(modelSpy).toHaveBeenCalledTimes(2);
-        });
+        if (role === userRoles.rider) {
+            await waitFor(() => {
+                expect(modelSpy).toHaveBeenCalledTimes(2);
+            });
+        }
         userEvent.click(screen.getByText("OK"));
         await waitFor(() => {
-            expect(saveSpy).toHaveBeenCalledTimes(4);
+            expect(saveSpy).toHaveBeenCalledTimes(
+                role === userRoles.rider ? 4 : 2
+            );
         });
         expect(saveSpy).toHaveBeenCalledWith(
             expect.objectContaining(_.omit(mockAssignments[0], "id"))
@@ -415,15 +419,6 @@ describe("MultipleSelectionActionsMenu", () => {
                 ...mockTask2,
                 status: expectedStatus,
                 riderResponsibility: assignee.riderResponsibility,
-            });
-        } else {
-            expect(saveSpy).toHaveBeenCalledWith({
-                ...mockTask,
-                status: expectedStatus,
-            });
-            expect(saveSpy).toHaveBeenCalledWith({
-                ...mockTask2,
-                status: expectedStatus,
             });
         }
         expect(screen.queryByTestId("CheckBoxIcon")).toBeNull();

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
@@ -544,11 +544,7 @@ describe("MultipleSelectionActionsMenu", () => {
         });
         expect(screen.queryByTestId("CheckBoxIcon")).toBeNull();
         await waitFor(() => {
-            // not sure what the difference is here
-            // seems like taskAssignees isn't getting refreshed when cancelled/rejected, but it does in the browser
-            expect(querySpy).toHaveBeenCalledTimes(
-                ["timeRejected", "timeCancelled"].includes(timeToSet) ? 4 : 6
-            );
+            expect(querySpy).toHaveBeenCalledTimes(4);
         });
         expect(
             await screen.findAllByTestId("CheckBoxOutlineBlankIcon")
@@ -559,7 +555,7 @@ describe("MultipleSelectionActionsMenu", () => {
         timeToSet
         ${"assignUser"} | ${"setTime"}
     `("shows the selection count", async ({ action }) => {
-        const mockTasks = await Promise.all(
+        await Promise.all(
             _.range(0, 10).map((i) =>
                 DataStore.save(new models.Task({ status: tasksStatus.new }))
             )

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
@@ -667,7 +667,7 @@ describe("MultipleSelectionActionsMenu", () => {
         });
         mockAllIsIntersecting(true);
         await waitFor(() => {
-            expect(querySpy).toHaveBeenCalledTimes(3);
+            expect(querySpy).toHaveBeenCalledTimes(2);
         });
         userEvent.click(screen.getByRole("button", { name: "Select All" }));
         userEvent.click(

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
@@ -82,7 +82,7 @@ describe("MultipleSelectionActionsMenu", () => {
         userEvent.click(screen.getByRole("button", { name: "Select All" }));
         expect(await screen.findAllByTestId("CheckBoxIcon")).toHaveLength(12);
     });
-    test.only.each`
+    test.each`
         taskStatus
         ${tasksStatus.completed} | ${tasksStatus.droppedOff} | ${tasksStatus.rejected} | ${tasksStatus.cancelled}
         ${tasksStatus.active}    | ${tasksStatus.pickedUp}   | ${tasksStatus.new}      | ${tasksStatus.droppedOff}

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
@@ -547,7 +547,7 @@ describe("MultipleSelectionActionsMenu", () => {
         });
         expect(screen.queryByTestId("CheckBoxIcon")).toBeNull();
         await waitFor(() => {
-            expect(querySpy).toHaveBeenCalledTimes(4);
+            expect(querySpy).toHaveBeenCalledTimes(5);
         });
         expect(
             await screen.findAllByTestId("CheckBoxOutlineBlankIcon")

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
@@ -566,6 +566,16 @@ describe("MultipleSelectionActionsMenu", () => {
             });
         });
         expect(screen.queryByTestId("CheckBoxIcon")).toBeNull();
+        await waitFor(() => {
+            // not sure what the difference is here
+            // seems like taskAssignees isn't getting refreshed when cancelled/rejected, but it does in the browser
+            expect(querySpy).toHaveBeenCalledTimes(
+                ["timeRejected", "timeCancelled"].includes(timeToSet) ? 4 : 6
+            );
+        });
+        expect(
+            await screen.findAllByTestId("CheckBoxOutlineBlankIcon")
+        ).toHaveLength(1);
     });
 
     it.each`

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
@@ -325,6 +325,7 @@ describe("MultipleSelectionActionsMenu", () => {
             new models.User({
                 roles: [role],
                 displayName: "Other Person",
+                riderResponsibility: "test",
             })
         );
         const mockAssignments = [mockTask, mockTask2].map(
@@ -404,15 +405,27 @@ describe("MultipleSelectionActionsMenu", () => {
             role === userRoles.coordinator
                 ? tasksStatus.new
                 : tasksStatus.active;
-        expect(saveSpy).toHaveBeenCalledWith({
-            ...mockTask,
-            status: expectedStatus,
-        });
-        expect(saveSpy).toHaveBeenCalledWith({
-            ...mockTask2,
-            status: expectedStatus,
-        });
-        console.log(role);
+        if (role === userRoles.rider) {
+            expect(saveSpy).toHaveBeenCalledWith({
+                ...mockTask,
+                status: expectedStatus,
+                riderResponsibility: assignee.riderResponsibility,
+            });
+            expect(saveSpy).toHaveBeenCalledWith({
+                ...mockTask2,
+                status: expectedStatus,
+                riderResponsibility: assignee.riderResponsibility,
+            });
+        } else {
+            expect(saveSpy).toHaveBeenCalledWith({
+                ...mockTask,
+                status: expectedStatus,
+            });
+            expect(saveSpy).toHaveBeenCalledWith({
+                ...mockTask2,
+                status: expectedStatus,
+            });
+        }
     });
 
     it.each`

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
@@ -426,6 +426,7 @@ describe("MultipleSelectionActionsMenu", () => {
                 status: expectedStatus,
             });
         }
+        expect(screen.queryByTestId("CheckBoxIcon")).toBeNull();
     });
 
     it.each`
@@ -564,6 +565,7 @@ describe("MultipleSelectionActionsMenu", () => {
                 [timeToSet]: isoDate,
             });
         });
+        expect(screen.queryByTestId("CheckBoxIcon")).toBeNull();
     });
 
     it.each`

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsMenu.test.js
@@ -69,7 +69,6 @@ describe("MultipleSelectionActionsMenu", () => {
                 preloadedState,
             }
         );
-        mockAllIsIntersecting(true);
         await waitFor(() => {
             expect(querySpy).toHaveBeenCalledTimes(1);
         });
@@ -128,7 +127,6 @@ describe("MultipleSelectionActionsMenu", () => {
                     preloadedState,
                 }
             );
-            mockAllIsIntersecting(true);
             await waitFor(() => {
                 expect(querySpy).toHaveBeenCalledTimes(1);
             });
@@ -268,7 +266,6 @@ describe("MultipleSelectionActionsMenu", () => {
                     preloadedState,
                 }
             );
-            mockAllIsIntersecting(true);
             await waitFor(() => {
                 expect(querySpy).toHaveBeenCalledTimes(1);
             });
@@ -361,7 +358,6 @@ describe("MultipleSelectionActionsMenu", () => {
                 preloadedState,
             }
         );
-        mockAllIsIntersecting(true);
         await waitFor(() => {
             expect(querySpy).toHaveBeenCalledTimes(1);
         });
@@ -506,7 +502,6 @@ describe("MultipleSelectionActionsMenu", () => {
                 preloadedState,
             }
         );
-        mockAllIsIntersecting(true);
         await waitFor(() => {
             expect(querySpy).toHaveBeenCalledTimes(1);
         });
@@ -611,7 +606,6 @@ describe("MultipleSelectionActionsMenu", () => {
                 preloadedState,
             }
         );
-        mockAllIsIntersecting(true);
         await waitFor(() => {
             expect(querySpy).toHaveBeenCalledTimes(1);
         });

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
@@ -48,7 +48,7 @@ function MultipleSelectionActionsSetTime({ selectedItems, timeKey, onChange }) {
 }
 
 MultipleSelectionActionsSetTime.propTypes = {
-    selectedItems: PropTypes.arrayOf(PropTypes.object),
+    selectedItems: PropTypes.object,
     timeKey: PropTypes.string.isRequired,
     onChange: PropTypes.func,
 };

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
 import { Divider, Stack, TextField } from "@mui/material";
 import * as models from "../../../models";
 import { DateTimePicker } from "@mui/lab";
@@ -45,5 +46,16 @@ function MultipleSelectionActionsSetTime({ selectedItems, timeKey, onChange }) {
         </Stack>
     );
 }
+
+MultipleSelectionActionsSetTime.propTypes = {
+    selectedItems: PropTypes.arrayOf(PropTypes.object),
+    timeKey: PropTypes.string.isRequired,
+    onChange: PropTypes.func,
+};
+
+MultipleSelectionActionsSetTime.defaultProps = {
+    selectedItems: [],
+    onChange: () => {},
+};
 
 export default MultipleSelectionActionsSetTime;

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
@@ -9,7 +9,6 @@ function isValidDate(d) {
 
 function MultipleSelectionActionsSetTime({ onChange, onReady }) {
     const [time, setTime] = React.useState(new Date());
-    const [isValid, setIsValid] = React.useState(true);
 
     function handleTimeChange(value) {
         setTime(value);
@@ -18,7 +17,7 @@ function MultipleSelectionActionsSetTime({ onChange, onReady }) {
     useEffect(() => {
         if (!isValidDate(time)) onChange(null);
         else onChange(time);
-    }, [isValid, onChange, time]);
+    }, [onChange, time]);
 
     return (
         <Stack spacing={2} direction="column" divider={<Divider />}>

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
@@ -7,7 +7,7 @@ function isValidDate(d) {
     return d instanceof Date && !isNaN(d);
 }
 
-function MultipleSelectionActionsSetTime({ onChange, onReady }) {
+function MultipleSelectionActionsSetTime({ onChange }) {
     const [time, setTime] = React.useState(new Date());
 
     function handleTimeChange(value) {
@@ -20,31 +20,24 @@ function MultipleSelectionActionsSetTime({ onChange, onReady }) {
     }, [onChange, time]);
 
     return (
-        <Stack spacing={2} direction="column" divider={<Divider />}>
-            <DateTimePicker
-                value={time}
-                inputFormat={"dd/MM/yyyy HH:mm"}
-                openTo="hours"
-                onChange={handleTimeChange}
-                renderInput={(params) => (
-                    <TextField variant={"standard"} fullWidth {...params} />
-                )}
-            />
-        </Stack>
+        <DateTimePicker
+            value={time}
+            inputFormat={"dd/MM/yyyy HH:mm"}
+            openTo="hours"
+            onChange={handleTimeChange}
+            renderInput={(params) => (
+                <TextField variant={"standard"} fullWidth {...params} />
+            )}
+        />
     );
 }
 
 MultipleSelectionActionsSetTime.propTypes = {
-    selectedItems: PropTypes.object,
-    timeKey: PropTypes.string.isRequired,
     onChange: PropTypes.func,
-    onReady: PropTypes.func,
 };
 
 MultipleSelectionActionsSetTime.defaultProps = {
-    selectedItems: [],
     onChange: () => {},
-    onReady: () => {},
 };
 
 export default MultipleSelectionActionsSetTime;

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
@@ -1,56 +1,25 @@
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { Divider, Stack, TextField } from "@mui/material";
-import * as models from "../../../models";
 import { DateTimePicker } from "@mui/lab";
-import { determineTaskStatus } from "../../../utilities";
 
 function isValidDate(d) {
     return d instanceof Date && !isNaN(d);
 }
 
-function MultipleSelectionActionsSetTime({
-    selectedItems,
-    timeKey,
-    onChange,
-    onReady,
-}) {
+function MultipleSelectionActionsSetTime({ onChange, onReady }) {
     const [time, setTime] = React.useState(new Date());
     const [isValid, setIsValid] = React.useState(true);
 
     function handleTimeChange(value) {
-        if (!isValidDate(value)) {
-            onReady(false);
-            setIsValid(false);
-            setTime(value);
-            return;
-        }
-        setIsValid(true);
         setTime(value);
     }
 
-    async function generatedModels() {
-        if (!selectedItems || !timeKey || !isValid) return;
-        onReady(false);
-        const newModels = await Promise.all(
-            Object.values(selectedItems).map(async (item) => {
-                const status = await determineTaskStatus({
-                    ...item,
-                    [timeKey]: time,
-                });
-                return models.Task.copyOf(item, (updated) => {
-                    updated[timeKey] = time.toISOString();
-                    updated.status = status;
-                });
-            })
-        );
-        onChange(newModels);
-        onReady(true);
-    }
-    useEffect(
-        () => generatedModels(),
-        [time, timeKey, selectedItems, onChange]
-    );
+    useEffect(() => {
+        if (!isValidDate(time)) onChange(null);
+        else onChange(time);
+    }, [isValid, onChange, time]);
+
     return (
         <Stack spacing={2} direction="column" divider={<Divider />}>
             <DateTimePicker

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from "react";
+import { Divider, Stack, TextField } from "@mui/material";
+import * as models from "../../../models";
+import { DateTimePicker } from "@mui/lab";
+import { determineTaskStatus } from "../../../utilities";
+
+function MultipleSelectionActionsSetTime({ selectedItems, timeKey, onChange }) {
+    const [time, setTime] = React.useState(new Date());
+
+    function handleTimeChange(value) {
+        setTime(value);
+    }
+
+    async function generatedModels() {
+        if (!selectedItems || !timeKey) return;
+        const newModels = await Promise.all(
+            Object.values(selectedItems).map(async (item) => {
+                const status = await determineTaskStatus({
+                    ...item,
+                    [timeKey]: time,
+                });
+                return models.Task.copyOf(item, (updated) => {
+                    updated[timeKey] = time.toISOString();
+                    updated.status = status;
+                });
+            })
+        );
+        onChange(newModels);
+    }
+    useEffect(
+        () => generatedModels(),
+        [time, timeKey, selectedItems, onChange]
+    );
+    return (
+        <Stack spacing={2} direction="column" divider={<Divider />}>
+            <DateTimePicker
+                value={time}
+                inputFormat={"dd/MM/yyyy HH:mm"}
+                openTo="hours"
+                onChange={handleTimeChange}
+                renderInput={(params) => (
+                    <TextField variant={"standard"} fullWidth {...params} />
+                )}
+            />
+        </Stack>
+    );
+}
+
+export default MultipleSelectionActionsSetTime;

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
@@ -5,15 +5,28 @@ import * as models from "../../../models";
 import { DateTimePicker } from "@mui/lab";
 import { determineTaskStatus } from "../../../utilities";
 
-function MultipleSelectionActionsSetTime({ selectedItems, timeKey, onChange }) {
+function isValidDate(d) {
+    return d instanceof Date && !isNaN(d);
+}
+
+function MultipleSelectionActionsSetTime({
+    selectedItems,
+    timeKey,
+    onChange,
+    onReady,
+}) {
     const [time, setTime] = React.useState(new Date());
 
     function handleTimeChange(value) {
+        if (!isValidDate(value)) {
+            return;
+        }
         setTime(value);
     }
 
     async function generatedModels() {
         if (!selectedItems || !timeKey) return;
+        onReady(false);
         const newModels = await Promise.all(
             Object.values(selectedItems).map(async (item) => {
                 const status = await determineTaskStatus({
@@ -27,6 +40,7 @@ function MultipleSelectionActionsSetTime({ selectedItems, timeKey, onChange }) {
             })
         );
         onChange(newModels);
+        onReady(true);
     }
     useEffect(
         () => generatedModels(),
@@ -51,11 +65,13 @@ MultipleSelectionActionsSetTime.propTypes = {
     selectedItems: PropTypes.object,
     timeKey: PropTypes.string.isRequired,
     onChange: PropTypes.func,
+    onReady: PropTypes.func,
 };
 
 MultipleSelectionActionsSetTime.defaultProps = {
     selectedItems: [],
     onChange: () => {},
+    onReady: () => {},
 };
 
 export default MultipleSelectionActionsSetTime;

--- a/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
+++ b/src/scenes/Dashboard/components/MultipleSelectionActionsSetTime.js
@@ -16,16 +16,21 @@ function MultipleSelectionActionsSetTime({
     onReady,
 }) {
     const [time, setTime] = React.useState(new Date());
+    const [isValid, setIsValid] = React.useState(true);
 
     function handleTimeChange(value) {
         if (!isValidDate(value)) {
+            onReady(false);
+            setIsValid(false);
+            setTime(value);
             return;
         }
+        setIsValid(true);
         setTime(value);
     }
 
     async function generatedModels() {
-        if (!selectedItems || !timeKey) return;
+        if (!selectedItems || !timeKey || !isValid) return;
         onReady(false);
         const newModels = await Promise.all(
             Object.values(selectedItems).map(async (item) => {

--- a/src/scenes/Dashboard/components/TaskCardsColoured.js
+++ b/src/scenes/Dashboard/components/TaskCardsColoured.js
@@ -224,11 +224,13 @@ TaskCard.propTypes = {
     riderResponsibility: PropTypes.string,
     timeOfCall: PropTypes.string,
     priority: PropTypes.string,
+    assignees: PropTypes.arrayOf(PropTypes.object),
 };
 
 TaskCard.defaultProps = {
     riderResponsibility: "",
     priority: "",
+    assignees: [],
 };
 
 export default TaskCard;

--- a/src/scenes/Dashboard/components/TaskCardsColoured.js
+++ b/src/scenes/Dashboard/components/TaskCardsColoured.js
@@ -218,8 +218,8 @@ const TaskCard = React.memo((props) => {
 });
 
 TaskCard.propTypes = {
-    pickUpAddress: PropTypes.object,
-    dropOffAddress: PropTypes.object,
+    pickUpLocation: PropTypes.object,
+    dropOffLocation: PropTypes.object,
     riderResponsibility: PropTypes.string,
     timeOfCall: PropTypes.string,
     priority: PropTypes.string,

--- a/src/scenes/Dashboard/components/TaskCardsColoured.js
+++ b/src/scenes/Dashboard/components/TaskCardsColoured.js
@@ -27,7 +27,6 @@ const generateClass = (theme, status) => {
         ${theme.palette.taskStatus[status]}
         ${colourBarPercent},
         ${theme.palette.taskStatus[status]} 100%)`,
-        cursor: "pointer",
     };
 };
 

--- a/src/scenes/Dashboard/components/TaskGridColumnHeader.js
+++ b/src/scenes/Dashboard/components/TaskGridColumnHeader.js
@@ -8,6 +8,7 @@ import IndeterminateCheckBoxIcon from "@mui/icons-material/IndeterminateCheckBox
 import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
 import { useDispatch, useSelector } from "react-redux";
 import {
+    dashboardFilterTermSelector,
     dashboardTabIndexSelector,
     selectedItemsSelector,
 } from "../../../redux/Selectors";
@@ -29,6 +30,7 @@ function TaskGridColumnHeader(props) {
     const selectedItemsAll = useSelector(selectedItemsSelector);
     const tabIndex = useSelector(dashboardTabIndexSelector);
     const dispatch = useDispatch();
+    const dashboardFilter = useSelector(dashboardFilterTermSelector);
 
     const classes = useStyles();
 
@@ -91,7 +93,7 @@ function TaskGridColumnHeader(props) {
             >
                 {props.title}
             </Typography>
-            {Object.values(props.tasks).length > 0 && (
+            {!!!dashboardFilter && Object.values(props.tasks).length > 0 && (
                 <Box sx={{ height: 0 }}>
                     <IconButton
                         data-testId={`${props.title}-select-all`}

--- a/src/scenes/Dashboard/components/TaskGridColumnHeader.js
+++ b/src/scenes/Dashboard/components/TaskGridColumnHeader.js
@@ -41,13 +41,16 @@ function TaskGridColumnHeader(props) {
                     .includes(t.id)
             )
         ) {
-            for (const task of Object.values(props.tasks)) {
-                dispatch(selectionActions.unselectItem(task.id, tabIndex));
-            }
+            dispatch(
+                selectionActions.unselectMultipleItems(
+                    Object.values(props.tasks).map((t) => t.id),
+                    tabIndex
+                )
+            );
         } else {
-            for (const task of Object.values(props.tasks)) {
-                dispatch(selectionActions.selectItem(task, tabIndex));
-            }
+            dispatch(
+                selectionActions.selectMultipleItems(props.tasks, tabIndex)
+            );
         }
     }
     function getCheckBox() {

--- a/src/scenes/Dashboard/components/TaskGridTasksList.js
+++ b/src/scenes/Dashboard/components/TaskGridTasksList.js
@@ -29,53 +29,54 @@ function TaskGridTasksList(props) {
             alignItems={"center"}
             justifyContent={"center"}
         >
-            {sortByCreatedTime(Object.values(props.tasks), "newest").map(
-                (task) => {
-                    displayDate = false;
-                    const timeComparison = new Date(
-                        task.createdAt || task.timeOfCall || null
-                    );
-                    if (
-                        timeComparison &&
-                        (filteredTasksIdsList.length === 0 ||
-                            filteredTasksIdsList.includes(task.id)) &&
-                        timeComparison.getDate() <= lastTime.getDate() - 1
-                    ) {
-                        lastTime = timeComparison;
-                        displayDate = true;
-                    }
-                    return (
-                        <Box
-                            className={clsx(
-                                classes.taskItem,
-                                props.includeList === null ||
-                                    props.includeList.includes(task.id)
-                                    ? show
-                                    : hide
-                            )}
-                            key={task.id}
-                        >
-                            <Box
-                                display="flex"
-                                justifyContent="center"
-                                alignItems="center"
-                                height={35}
-                                sx={{ width: "100%" }}
-                            >
-                                {displayDate && (
-                                    <DateStampDivider date={lastTime} />
-                                )}
-                            </Box>
-                            <TaskItem
-                                animate={props.animate}
-                                task={task}
-                                taskUUID={task.id}
-                                deleteDisabled
-                            />
-                        </Box>
-                    );
+            {sortByCreatedTime(
+                Object.values(props.tasks).reverse(),
+                "newest"
+            ).map((task) => {
+                displayDate = false;
+                const timeComparison = new Date(
+                    task.createdAt || task.timeOfCall || null
+                );
+                if (
+                    timeComparison &&
+                    (filteredTasksIdsList.length === 0 ||
+                        filteredTasksIdsList.includes(task.id)) &&
+                    timeComparison.getDate() <= lastTime.getDate() - 1
+                ) {
+                    lastTime = timeComparison;
+                    displayDate = true;
                 }
-            )}
+                return (
+                    <Box
+                        className={clsx(
+                            classes.taskItem,
+                            props.includeList === null ||
+                                props.includeList.includes(task.id)
+                                ? show
+                                : hide
+                        )}
+                        key={task.id}
+                    >
+                        <Box
+                            display="flex"
+                            justifyContent="center"
+                            alignItems="center"
+                            height={35}
+                            sx={{ width: "100%" }}
+                        >
+                            {displayDate && (
+                                <DateStampDivider date={lastTime} />
+                            )}
+                        </Box>
+                        <TaskItem
+                            animate={props.animate}
+                            task={task}
+                            taskUUID={task.id}
+                            deleteDisabled
+                        />
+                    </Box>
+                );
+            })}
         </Stack>
     );
 }

--- a/src/scenes/Dashboard/components/TaskGridTasksList.js
+++ b/src/scenes/Dashboard/components/TaskGridTasksList.js
@@ -29,54 +29,53 @@ function TaskGridTasksList(props) {
             alignItems={"center"}
             justifyContent={"center"}
         >
-            {sortByCreatedTime(
-                Object.values(props.tasks).reverse(),
-                "newest"
-            ).map((task) => {
-                displayDate = false;
-                const timeComparison = new Date(
-                    task.createdAt || task.timeOfCall || null
-                );
-                if (
-                    timeComparison &&
-                    (filteredTasksIdsList.length === 0 ||
-                        filteredTasksIdsList.includes(task.id)) &&
-                    timeComparison.getDate() <= lastTime.getDate() - 1
-                ) {
-                    lastTime = timeComparison;
-                    displayDate = true;
-                }
-                return (
-                    <Box
-                        className={clsx(
-                            classes.taskItem,
-                            props.includeList === null ||
-                                props.includeList.includes(task.id)
-                                ? show
-                                : hide
-                        )}
-                        key={task.id}
-                    >
+            {sortByCreatedTime(Object.values(props.tasks), "newest").map(
+                (task) => {
+                    displayDate = false;
+                    const timeComparison = new Date(
+                        task.createdAt || task.timeOfCall || null
+                    );
+                    if (
+                        timeComparison &&
+                        (filteredTasksIdsList.length === 0 ||
+                            filteredTasksIdsList.includes(task.id)) &&
+                        timeComparison.getDate() <= lastTime.getDate() - 1
+                    ) {
+                        lastTime = timeComparison;
+                        displayDate = true;
+                    }
+                    return (
                         <Box
-                            display="flex"
-                            justifyContent="center"
-                            alignItems="center"
-                            height={35}
-                            sx={{ width: "100%" }}
-                        >
-                            {displayDate && (
-                                <DateStampDivider date={lastTime} />
+                            className={clsx(
+                                classes.taskItem,
+                                props.includeList === null ||
+                                    props.includeList.includes(task.id)
+                                    ? show
+                                    : hide
                             )}
+                            key={task.id}
+                        >
+                            <Box
+                                display="flex"
+                                justifyContent="center"
+                                alignItems="center"
+                                height={35}
+                                sx={{ width: "100%" }}
+                            >
+                                {displayDate && (
+                                    <DateStampDivider date={lastTime} />
+                                )}
+                            </Box>
+                            <TaskItem
+                                animate={props.animate}
+                                task={task}
+                                taskUUID={task.id}
+                                deleteDisabled
+                            />
                         </Box>
-                        <TaskItem
-                            animate={props.animate}
-                            task={task}
-                            taskUUID={task.id}
-                            deleteDisabled
-                        />
-                    </Box>
-                );
-            })}
+                    );
+                }
+            )}
         </Stack>
     );
 }

--- a/src/scenes/Dashboard/components/TaskItem.js
+++ b/src/scenes/Dashboard/components/TaskItem.js
@@ -30,9 +30,6 @@ const useStyles = (isSelected) =>
     makeStyles((theme) => ({
         root: {
             position: "relative",
-            backgroundColor: isSelected
-                ? alpha(theme.palette.primary.main, 0.3)
-                : "transparent",
             "&:hover": {
                 "& $dots": {
                     display: isSelected ? "none" : "inline",
@@ -40,10 +37,25 @@ const useStyles = (isSelected) =>
                 "& $select": {
                     display: "inline",
                 },
+                "& $overlay": {
+                    display: "inline",
+                },
             },
             padding: 1,
             width: "100%",
             cursor: "context-menu",
+        },
+        overlay: {
+            position: "absolute",
+            display: isSelected ? "inline" : "none",
+            top: 0,
+            left: 0,
+            pointerEvents: "none",
+            background: isSelected
+                ? alpha(theme.palette.primary.main, 0.3)
+                : alpha(theme.palette.background.paper, 0.3),
+            width: "100%",
+            height: "100%",
         },
         dots: () => {
             const background =
@@ -122,6 +134,7 @@ const ItemWrapper = ({
             </Link>
         );
 };
+
 function TaskItemWrapper(props) {
     const location = useLocation();
     return <TaskItem {...props} location={location} />;
@@ -316,6 +329,7 @@ function TaskItem(props) {
                         </div>
                     </>
                 )}
+                <div className={classes.overlay} />
             </Box>
         </Grow>
     ) : (

--- a/src/scenes/Dashboard/components/TaskItem.js
+++ b/src/scenes/Dashboard/components/TaskItem.js
@@ -39,6 +39,9 @@ const useStyles = (isSelected) =>
                 },
                 "& $overlay": {
                     display: "inline",
+                    [theme.breakpoints.down("sm")]: {
+                        display: isSelected ? "inline" : "none",
+                    },
                 },
             },
             padding: 1,

--- a/src/scenes/Dashboard/components/TasksGrid.js
+++ b/src/scenes/Dashboard/components/TasksGrid.js
@@ -2,15 +2,10 @@ import React from "react";
 import _ from "lodash";
 import Grid from "@mui/material/Grid";
 import PropTypes from "prop-types";
-import useMediaQuery from "@mui/material/useMediaQuery";
-import { useTheme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
 import TasksGridColumn from "./TasksGridColumn";
 import { tasksStatus, userRoles } from "../../../apiConsts";
-import {
-    dashboardFilteredUserSelector,
-    getRoleView,
-} from "../../../redux/Selectors";
+import { dashboardFilteredUserSelector } from "../../../redux/Selectors";
 import { useSelector } from "react-redux";
 
 const getColumnTitle = (key) => {
@@ -52,7 +47,6 @@ const useStyles = makeStyles((theme) => ({
 
 function TasksGrid(props) {
     const classes = useStyles();
-    const theme = useTheme();
     const dashboardFilteredUser = useSelector(dashboardFilteredUserSelector);
 
     let justifyContent = "flex-start";
@@ -107,7 +101,5 @@ TasksGrid.propTypes = {
     excludeColumnList: PropTypes.arrayOf(PropTypes.string),
     isFetching: PropTypes.bool,
 };
-
-TasksGrid.whyDidYouRender = true;
 
 export default TasksGrid;

--- a/src/scenes/Dashboard/components/TasksGridColumn.jsx
+++ b/src/scenes/Dashboard/components/TasksGridColumn.jsx
@@ -1,19 +1,9 @@
 import React, { useEffect, useRef, useState } from "react";
 import _ from "lodash";
-import TaskItem from "./TaskItem";
 import * as models from "../../../models/index";
-import { useDispatch, useSelector } from "react-redux";
-import Tooltip from "@mui/material/Tooltip";
-import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
-import {
-    IconButton,
-    Skeleton,
-    Stack,
-    Typography,
-    useMediaQuery,
-} from "@mui/material";
+import { useSelector } from "react-redux";
+import { Skeleton, Stack, useMediaQuery } from "@mui/material";
 import PropTypes from "prop-types";
-import { showHide } from "../../../styles/common";
 import makeStyles from "@mui/styles/makeStyles";
 import {
     dashboardFilteredUserSelector,
@@ -27,39 +17,21 @@ import {
     dashboardTabIndexSelector,
     selectionActionsPendingSelector,
 } from "../../../redux/Selectors";
-import { sortByCreatedTime } from "../../../utilities";
 import { DataStore } from "aws-amplify";
 import { filterTasks } from "../utilities/functions";
 import GetError from "../../../ErrorComponents/GetError";
 import { userRoles } from "../../../apiConsts";
 import Box from "@mui/material/Box";
-import DateStampDivider from "./TimeStampDivider";
 import getTasksAll from "../utilities/getTasksAll";
 import getAllTasksByUser from "../utilities/getAllTasksByUser";
 import getAllMyTasks from "../utilities/getAllMyTasks";
 import getAllMyTasksWithUser from "../utilities/getAllMyTasksWithUser";
 import useWindowSize from "../../../hooks/useWindowSize";
 import { useTheme } from "@mui/styles";
-import { useInView } from "react-intersection-observer";
 import TaskGridColumnHeader from "./TaskGridColumnHeader";
 import TaskGridTasksList from "./TaskGridTasksList";
 
-const loaderStyles = makeStyles((theme) => ({
-    linear: {
-        width: "100%",
-        "& > * + *": {
-            marginTop: theme.spacing(2),
-        },
-    },
-    circular: {
-        display: "flex",
-        "& > * + *": {
-            marginLeft: theme.spacing(2),
-        },
-    },
-}));
-
-const useStyles = (isSelected) =>
+const useStyles = () =>
     makeStyles((theme) => ({
         divider: {
             width: "95%",
@@ -98,7 +70,6 @@ function TasksGridColumn(props) {
     const [isFetching, setIsFetching] = useState(true);
     const [errorState, setErrorState] = useState(false);
     const [filteredTasksIds, setFilteredTasksIds] = useState(null);
-    const [visibility, setVisibility] = useState(false);
     const [width, height] = useWindowSize();
     const whoami = useSelector(getWhoami);
     const dashboardFilter = useSelector(dashboardFilterTermSelector);
@@ -121,10 +92,6 @@ function TasksGridColumn(props) {
         unsubscribe: () => {},
     });
     const theme = useTheme();
-    const { ref, inView, entry } = useInView({
-        threshold: 0,
-    });
-
     useEffect(() => {
         const selectedItems = selectedItemsAll[tabIndex];
         if (!selectedItems) return;
@@ -135,12 +102,6 @@ function TasksGridColumn(props) {
     });
 
     const classes = useStyles(isSomeSelected.current)();
-
-    useEffect(() => {
-        if (inView && !visibility) {
-            setVisibility(true);
-        }
-    }, [inView]);
 
     const isSm = useMediaQuery(theme.breakpoints.down("sm"));
 
@@ -169,12 +130,7 @@ function TasksGridColumn(props) {
     useEffect(doSearch, [dashboardFilter, state]);
 
     async function getTasks() {
-        if (
-            !roleView ||
-            !visibility ||
-            !taskAssigneesReady ||
-            selectionActionsPending
-        ) {
+        if (!roleView || !taskAssigneesReady || selectionActionsPending) {
             return;
         } else {
             try {
@@ -234,7 +190,6 @@ function TasksGridColumn(props) {
             selectionActionsPending,
             dashboardFilteredUser,
             taskAssigneesReady,
-            visibility,
             roleView,
             JSON.stringify(props.taskKey),
         ]
@@ -420,7 +375,6 @@ function TasksGridColumn(props) {
         return (
             <Box
                 className={classes.column}
-                ref={ref}
                 sx={{
                     width: isSm ? "100%" : width / 4.2,
                 }}
@@ -448,7 +402,6 @@ function TasksGridColumn(props) {
         return (
             <Box
                 className={classes.column}
-                ref={ref}
                 sx={{
                     width: isSm ? "100%" : width / 4.2,
                 }}

--- a/src/scenes/Dashboard/components/TasksGridColumn.test.js
+++ b/src/scenes/Dashboard/components/TasksGridColumn.test.js
@@ -472,11 +472,10 @@ describe("TasksGridColumn", () => {
             status: tasksStatus.new,
             timeOfCall,
         });
+        const querySpy = jest.spyOn(DataStore, "query");
         render(<TasksGridColumn taskKey={[tasksStatus.new]} />, {
             preloadedState,
         });
-        const querySpy = jest.spyOn(DataStore, "query");
-        mockAllIsIntersecting(true);
         await waitFor(() => {
             expect(querySpy).toHaveBeenNthCalledWith(
                 1,
@@ -521,11 +520,10 @@ describe("TasksGridColumn", () => {
             status: tasksStatus.active,
             timeOfCall,
         });
+        const querySpy = jest.spyOn(DataStore, "query");
         render(<TasksGridColumn taskKey={[tasksStatus.new]} />, {
             preloadedState,
         });
-        const querySpy = jest.spyOn(DataStore, "query");
-        mockAllIsIntersecting(true);
         await waitFor(() => {
             expect(querySpy).toHaveBeenNthCalledWith(
                 1,

--- a/src/scenes/Dashboard/components/TasksGridColumn.test.js
+++ b/src/scenes/Dashboard/components/TasksGridColumn.test.js
@@ -1079,6 +1079,51 @@ describe("TasksGridColumn", () => {
         ).toHaveLength(3);
     });
 
+    test.skip("long press in mobile view to select", async () => {
+        // not working yet
+        global.innerWidth = 100;
+        global.dispatchEvent(new Event("resize"));
+        await DataStore.save(new models.Task({ status: tasksStatus.new }));
+        const mockWhoami = await DataStore.save(
+            new models.User({
+                roles: [userRoles.coordinator],
+                displayName: "Someone Person",
+            })
+        );
+        const preloadedState = {
+            roleView: "ALL",
+            dashboardTabIndex: 1,
+            whoami: { user: mockWhoami },
+            taskAssigneesReducer: {
+                items: [],
+                ready: true,
+                isSynced: true,
+            },
+        };
+        const querySpy = jest.spyOn(DataStore, "query");
+        render(<TasksGridColumn taskKey={[tasksStatus.new]} />, {
+            preloadedState,
+        });
+        mockAllIsIntersecting(true);
+        await waitFor(() => {
+            expect(querySpy).toHaveBeenCalledTimes(1);
+        });
+        mockAllIsIntersecting(true);
+        await waitFor(() => {
+            expect(querySpy).toHaveBeenCalledTimes(2);
+        });
+        // simulate a long press
+        const longPress = new MouseEvent("mousedown", {
+            bubbles: true,
+            cancelable: true,
+            clientX: 0,
+            clientY: 0,
+            button: 0,
+        });
+        const taskItem = await screen.findByTestId("task-item-parent");
+        taskItem.dispatchEvent(longPress);
+    });
+
     test("select all the items in a column", async () => {
         for (const i in _.range(0, 10)) {
             await DataStore.save(new models.Task({ status: tasksStatus.new }));

--- a/src/scenes/Dashboard/utilities/generateMultipleAssignmentModels.js
+++ b/src/scenes/Dashboard/utilities/generateMultipleAssignmentModels.js
@@ -1,0 +1,70 @@
+import _ from "lodash";
+import { userRoles } from "../../../apiConsts";
+import * as models from "../../../models";
+import { determineTaskStatus } from "../../../utilities";
+
+async function generateMultipleAssignmentModels(
+    selectedItems,
+    coordinators,
+    riders,
+    allAssignees
+) {
+    if (_.isEmpty(coordinators) && _.isEmpty(riders)) {
+        return;
+    }
+    const ridersMapped = Object.values(selectedItems).map((task) => {
+        return Object.values(riders).map((assignee) => {
+            return new models.TaskAssignee({
+                assignee,
+                task,
+                role: userRoles.rider,
+            });
+        });
+    });
+    const coordinatorsMapped = Object.values(selectedItems).map((task) => {
+        return Object.values(coordinators).map(
+            (assignee) =>
+                new models.TaskAssignee({
+                    assignee,
+                    task,
+                    role: userRoles.coordinator,
+                })
+        );
+    });
+    const result = [...ridersMapped, ...coordinatorsMapped].flat(2);
+    const filtered = result.filter((assignment) => {
+        return !allAssignees.items.some((assignee) => {
+            return (
+                assignment.task.id === assignee.task.id &&
+                assignment.assignee.id === assignee.assignee.id &&
+                assignment.role === assignee.role
+            );
+        });
+    });
+    let newTasks = [];
+    if (ridersMapped.flat().length > 0) {
+        newTasks = await Promise.all(
+            Object.values(selectedItems).map(async (task) => {
+                const status = await determineTaskStatus(
+                    task,
+                    ridersMapped.flat()
+                );
+                let riderResponsibility = task.riderResponsibility;
+                for (const rider of ridersMapped
+                    .flat()
+                    .map((assignment) => assignment.assignee)) {
+                    if (rider.riderResponsibility) {
+                        riderResponsibility = rider.riderResponsibility;
+                    }
+                }
+                return models.Task.copyOf(task, (updated) => {
+                    updated.status = status;
+                    updated.riderResponsibility = riderResponsibility;
+                });
+            })
+        );
+    }
+    return [...filtered, ...newTasks];
+}
+
+export default generateMultipleAssignmentModels;

--- a/src/scenes/Dashboard/utilities/generateMultipleTaskComments.js
+++ b/src/scenes/Dashboard/utilities/generateMultipleTaskComments.js
@@ -1,8 +1,9 @@
+import _ from "lodash";
 import { commentVisibility } from "../../../apiConsts";
 import * as models from "../../../models";
 
 async function generateMultipleTaskComments(selectedItems, body, author) {
-    if (!selectedItems || !body || !author) return;
+    if (!selectedItems || _.isEmpty(selectedItems) || !body || !author) return;
     return await Promise.all(
         Object.values(selectedItems).map(async (item) => {
             return new models.Comment({

--- a/src/scenes/Dashboard/utilities/generateMultipleTaskComments.js
+++ b/src/scenes/Dashboard/utilities/generateMultipleTaskComments.js
@@ -1,0 +1,18 @@
+import { commentVisibility } from "../../../apiConsts";
+import * as models from "../../../models";
+
+async function generateMultipleTaskComments(selectedItems, body, author) {
+    if (!selectedItems || !body || !author) return;
+    return await Promise.all(
+        Object.values(selectedItems).map(async (item) => {
+            return new models.Comment({
+                body: body,
+                parentId: item.id,
+                visibility: commentVisibility.everyone,
+                author: author,
+            });
+        })
+    );
+}
+
+export default generateMultipleTaskComments;

--- a/src/scenes/Dashboard/utilities/generateMultipleTaskTimeModels.js
+++ b/src/scenes/Dashboard/utilities/generateMultipleTaskTimeModels.js
@@ -1,0 +1,20 @@
+import { determineTaskStatus } from "../../../utilities";
+import * as models from "../../../models";
+
+async function generateMultipleTaskTimeModels(selectedItems, timeKey, time) {
+    if (!selectedItems || !timeKey) return;
+    return await Promise.all(
+        Object.values(selectedItems).map(async (item) => {
+            const status = await determineTaskStatus({
+                ...item,
+                [timeKey]: time,
+            });
+            return models.Task.copyOf(item, (updated) => {
+                updated[timeKey] = time.toISOString();
+                updated.status = status;
+            });
+        })
+    );
+}
+
+export default generateMultipleTaskTimeModels;

--- a/src/scenes/Dashboard/utilities/generateMultipleTaskTimeModels.js
+++ b/src/scenes/Dashboard/utilities/generateMultipleTaskTimeModels.js
@@ -1,14 +1,22 @@
 import { determineTaskStatus } from "../../../utilities";
 import * as models from "../../../models";
 
-async function generateMultipleTaskTimeModels(selectedItems, timeKey, time) {
+async function generateMultipleTaskTimeModels(
+    selectedItems,
+    timeKey,
+    time,
+    riderAssignees
+) {
     if (!selectedItems || !timeKey) return;
     return await Promise.all(
         Object.values(selectedItems).map(async (item) => {
-            const status = await determineTaskStatus({
-                ...item,
-                [timeKey]: time,
-            });
+            const status = await determineTaskStatus(
+                {
+                    ...item,
+                    [timeKey]: time,
+                },
+                riderAssignees
+            );
             return models.Task.copyOf(item, (updated) => {
                 updated[timeKey] = time.toISOString();
                 updated.status = status;

--- a/src/scenes/Dashboard/utilities/generateMultipleTaskTimeModels.js
+++ b/src/scenes/Dashboard/utilities/generateMultipleTaskTimeModels.js
@@ -1,5 +1,7 @@
 import { determineTaskStatus } from "../../../utilities";
 import * as models from "../../../models";
+import { DataStore } from "aws-amplify";
+import _ from "lodash";
 
 async function generateMultipleTaskTimeModels(
     selectedItems,
@@ -7,9 +9,16 @@ async function generateMultipleTaskTimeModels(
     time,
     riderAssignees
 ) {
-    if (!selectedItems || !timeKey) return;
+    if (!selectedItems || _.isEmpty(selectedItems) || !timeKey) return;
+    const filteredTasks = await DataStore.query(models.Task, (task) =>
+        task.or((task) =>
+            Object.values(selectedItems)
+                .map((t) => t.id)
+                .reduce((task, id) => task.id("eq", id), task)
+        )
+    );
     return await Promise.all(
-        Object.values(selectedItems).map(async (item) => {
+        filteredTasks.map(async (item) => {
             const status = await determineTaskStatus(
                 {
                     ...item,

--- a/src/scenes/Task/components/LocationDetailsPanel.js
+++ b/src/scenes/Task/components/LocationDetailsPanel.js
@@ -54,7 +54,6 @@ function LocationDetailsPanel(props) {
                 task.id
             ).subscribe(({ opType, element }) => {
                 if (opType === "UPDATE") {
-                    debugger;
                     const locId = element[`${props.locationKey}Id`];
                     if ((!state && locId) || (state && locId !== state.id)) {
                         DataStore.query(models.Location, locId).then((result) =>

--- a/src/scenes/Task/components/StatusBar.js
+++ b/src/scenes/Task/components/StatusBar.js
@@ -109,7 +109,6 @@ function StatusBar(props) {
     useEffect(() => getTask(), [props.taskId, taskModelsSynced]);
 
     async function copyToClipboard() {
-        debugger;
         if (!props.taskId) {
             dispatch(displayErrorNotification("Copy failed."));
             return;

--- a/src/scenes/Task/components/TaskActionConfirmationDialogContents.js
+++ b/src/scenes/Task/components/TaskActionConfirmationDialogContents.js
@@ -35,6 +35,7 @@ TaskActionConfirmationDialogContents.propTypes = {
         "timeDroppedOff",
         "timeRejected",
         "timeCancelled",
+        "timeRiderHome",
     ]).isRequired,
     nullify: PropTypes.bool.isRequired,
 };

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -135,26 +135,38 @@ export function taskStatusHumanReadable(status) {
 
 export function sortByCreatedTime(items, order = "newest") {
     if (!items || items.length === 0) return [];
-    if (order !== "newest")
+    if (order !== "newest") {
         return items.sort((a, b) => {
             return new Date(a.createdAt) - new Date(b.createdAt);
         });
-    else
+    } else {
         return items.sort((a, b) => {
+            if (!a.createdAt) {
+                return 1;
+            } else if (!b.createdAt) {
+                return -1;
+            }
             return new Date(b.createdAt) - new Date(a.createdAt);
         });
+    }
 }
 
 export function sortByTimeOfCall(items, order = "newest") {
     if (!items || items.length === 0) return [];
-    if (order !== "newest")
+    if (order !== "newest") {
         return items.sort((a, b) => {
             return new Date(a.timeOfCall) - new Date(b.timeOfCall);
         });
-    else
+    } else {
         return items.sort((a, b) => {
+            if (!a.timeOfCall) {
+                return 1;
+            } else if (!b.timeOfCall) {
+                return -1;
+            }
             return new Date(b.timeOfCall) - new Date(a.timeOfCall);
         });
+    }
 }
 
 export function encodeUUID(uuid) {


### PR DESCRIPTION
This pull request adds selection options to the main dashboard.

The user can select individual items, individual columns or all items on the active dashboard tab.

![image](https://user-images.githubusercontent.com/32309223/171926647-b6c0d9ac-d66f-4b4a-92c5-53049aef95e0.png)

Selection of an individual task is by hovering over the card first and clicking the checkbox.

![image](https://user-images.githubusercontent.com/32309223/171927571-91e3cbcd-ad53-49d8-9233-07fb6f0d844d.png)

In the selection toolbar buttons are enabled or disabled depending on the available actions (here only active tasks are selected, so the PICKED UP button is enabled, but not delivered or rider home).

![image](https://user-images.githubusercontent.com/32309223/171926787-9743b1a1-1ad6-4374-918c-177306a843aa.png)

Rider chips filters can be used to select only items from certain users using the column select checkbox. However if the dashboard filter is applied, only individual tasks can be selected.

![image](https://user-images.githubusercontent.com/32309223/171927072-11322b25-4ff6-47fe-902e-884505c52f7e.png)

Dialog for entering a time. Cancelled or rejected items ask for a reason which is then added to each task as a comment.

![image](https://user-images.githubusercontent.com/32309223/171928073-a834fffc-37c8-4ffa-8563-8f4360bf3c71.png)

Clicking the items link shows a preview of all affected tasks.

![image](https://user-images.githubusercontent.com/32309223/171928362-67a1b6cb-1189-419a-99c5-58c9840331e6.png)

Assign users to tasks. You can assign more than one person of either role.

![image](https://user-images.githubusercontent.com/32309223/171928544-1be18ff1-cc62-448c-9f19-0a58e95fdaf2.png)

Mobile view places the toolbar at the bottom of the screen. Long press cards to select an item. You can only select by column in mobile view and not all tasks. Cancelled and rejected are placed in the three dot menu.

![Screen Shot 2022-06-03 at 19 50 23](https://user-images.githubusercontent.com/32309223/171928931-0fd71a06-53f9-4ee9-bd2b-3e889f7fc742.png)

Dialogs look the same as in desktop but are full screen.

![Screen Shot 2022-06-03 at 19 52 38](https://user-images.githubusercontent.com/32309223/171929564-66b5a16b-6871-4615-aa9c-5b039deb5d58.png)

A demo build exists at https://selection.d1yif924l5w2t0.amplifyapp.com/ data is only stored locally, so you can interact with the dashboard and it won't affect anything.

@PaulFreewheelersEVS
@ianphunt58

Can you please review when you next have some time?