### PR TITLE
Add toggle for rider using their own vehicle

### DIFF
--- a/amplify/backend/api/platelet/schema.graphql
+++ b/amplify/backend/api/platelet/schema.graphql
@@ -214,6 +214,7 @@ timePickedUpSenderName: String
   deliverables: [Deliverable] @hasMany
   comments: [Comment] @hasMany(indexName: "byParent", fields: ["id"])
   status: TaskStatus @index(name: "byStatus", queryField: "tasksByStatus")
+  isRiderUsingOwnVehicle: Int @default(value: "0")
 }
 
 type TaskAssignee

--- a/amplify/backend/backend-config.json
+++ b/amplify/backend/backend-config.json
@@ -1,280 +1,498 @@
 {
-  "auth": {
-    "platelet61a0ac07": {
-      "service": "Cognito",
-      "providerPlugin": "awscloudformation",
-      "dependsOn": [],
-      "customAuth": false,
-      "frontendAuthConfig": {
-        "socialProviders": [],
-        "usernameAttributes": [],
-        "signupAttributes": [
-          "EMAIL"
-        ],
-        "passwordProtectionSettings": {
-          "passwordPolicyMinLength": 8,
-          "passwordPolicyCharacters": []
-        },
-        "mfaConfiguration": "OFF",
-        "mfaTypes": [
-          "SMS"
-        ],
-        "verificationMechanisms": [
-          "EMAIL"
-        ]
-      }
-    },
-    "userPoolGroups": {
-      "service": "Cognito-UserPool-Groups",
-      "providerPlugin": "awscloudformation",
-      "dependsOn": [
-        {
-          "category": "auth",
-          "resourceName": "platelet61a0ac07",
-          "attributes": [
-            "UserPoolId",
-            "AppClientIDWeb",
-            "AppClientID",
-            "IdentityPoolId"
-          ]
-        }
-      ]
-    }
-  },
   "api": {
     "platelet": {
-      "service": "AppSync",
-      "providerPlugin": "awscloudformation",
+      "dependsOn": [
+        {
+          "attributes": [
+            "UserPoolId"
+          ],
+          "category": "auth",
+          "resourceName": "platelet61a0ac07"
+        }
+      ],
       "output": {
         "authConfig": {
+          "additionalAuthenticationProviders": [
+            {
+              "authenticationType": "AWS_IAM"
+            }
+          ],
           "defaultAuthentication": {
             "authenticationType": "AMAZON_COGNITO_USER_POOLS",
             "userPoolConfig": {
               "userPoolId": "authplatelet61a0ac07"
             }
-          },
-          "additionalAuthenticationProviders": [
-            {
-              "authenticationType": "AWS_IAM"
-            }
-          ]
+          }
         }
       },
-      "dependsOn": [
-        {
-          "category": "auth",
-          "resourceName": "platelet61a0ac07",
-          "attributes": [
-            "UserPoolId"
-          ]
-        }
-      ]
+      "providerPlugin": "awscloudformation",
+      "service": "AppSync"
     }
   },
+  "auth": {
+    "platelet61a0ac07": {
+      "customAuth": false,
+      "dependsOn": [],
+      "frontendAuthConfig": {
+        "mfaConfiguration": "OFF",
+        "mfaTypes": [
+          "SMS"
+        ],
+        "passwordProtectionSettings": {
+          "passwordPolicyCharacters": [],
+          "passwordPolicyMinLength": 8
+        },
+        "signupAttributes": [
+          "EMAIL"
+        ],
+        "socialProviders": [],
+        "usernameAttributes": [],
+        "verificationMechanisms": [
+          "EMAIL"
+        ]
+      },
+      "providerPlugin": "awscloudformation",
+      "service": "Cognito"
+    },
+    "userPoolGroups": {
+      "dependsOn": [
+        {
+          "attributes": [
+            "UserPoolId",
+            "AppClientIDWeb",
+            "AppClientID",
+            "IdentityPoolId"
+          ],
+          "category": "auth",
+          "resourceName": "platelet61a0ac07"
+        }
+      ],
+      "providerPlugin": "awscloudformation",
+      "service": "Cognito-UserPool-Groups"
+    }
+  },
+  "custom": {},
   "function": {
     "PlateletTaskResolvers": {
       "build": true,
       "providerPlugin": "awscloudformation",
       "service": "Lambda"
     },
-    "plateletImageResize": {
+    "plateletAddNewTenant": {
       "build": true,
-      "providerPlugin": "awscloudformation",
-      "service": "Lambda",
       "dependsOn": [
         {
-          "category": "storage",
-          "resourceName": "plateletStorage",
           "attributes": [
-            "BucketName"
-          ]
+            "UserPoolId"
+          ],
+          "category": "auth",
+          "resourceName": "platelet61a0ac07"
+        },
+        {
+          "attributes": [
+            "GraphQLAPIIdOutput",
+            "GraphQLAPIEndpointOutput"
+          ],
+          "category": "api",
+          "resourceName": "platelet"
         }
-      ]
+      ],
+      "providerPlugin": "awscloudformation",
+      "service": "Lambda"
     },
     "plateletAdminAddNewUser": {
       "build": true,
-      "providerPlugin": "awscloudformation",
-      "service": "Lambda",
       "dependsOn": [
         {
-          "category": "auth",
-          "resourceName": "platelet61a0ac07",
           "attributes": [
             "UserPoolId"
-          ]
+          ],
+          "category": "auth",
+          "resourceName": "platelet61a0ac07"
         },
         {
-          "category": "api",
-          "resourceName": "platelet",
           "attributes": [
             "GraphQLAPIIdOutput",
             "GraphQLAPIEndpointOutput"
-          ]
-        }
-      ]
-    },
-    "plateletAddNewTenant": {
-      "build": true,
-      "providerPlugin": "awscloudformation",
-      "service": "Lambda",
-      "dependsOn": [
-        {
-          "category": "auth",
-          "resourceName": "platelet61a0ac07",
-          "attributes": [
-            "UserPoolId"
-          ]
-        },
-        {
+          ],
           "category": "api",
-          "resourceName": "platelet",
-          "attributes": [
-            "GraphQLAPIIdOutput",
-            "GraphQLAPIEndpointOutput"
-          ]
+          "resourceName": "platelet"
         }
-      ]
+      ],
+      "providerPlugin": "awscloudformation",
+      "service": "Lambda"
     },
     "plateletAdminChangeUserRoles": {
       "build": true,
-      "providerPlugin": "awscloudformation",
-      "service": "Lambda",
       "dependsOn": [
         {
-          "category": "auth",
-          "resourceName": "platelet61a0ac07",
           "attributes": [
             "UserPoolId"
-          ]
+          ],
+          "category": "auth",
+          "resourceName": "platelet61a0ac07"
         },
         {
-          "category": "api",
-          "resourceName": "platelet",
           "attributes": [
             "GraphQLAPIIdOutput",
             "GraphQLAPIEndpointOutput"
-          ]
+          ],
+          "category": "api",
+          "resourceName": "platelet"
         }
-      ]
-    },
-    "plateletProfilePictureUploadURLResolver": {
-      "build": true,
+      ],
       "providerPlugin": "awscloudformation",
-      "service": "Lambda",
+      "service": "Lambda"
+    },
+    "plateletImageResize": {
+      "build": true,
       "dependsOn": [
         {
-          "category": "api",
-          "resourceName": "platelet",
-          "attributes": [
-            "GraphQLAPIIdOutput",
-            "GraphQLAPIEndpointOutput"
-          ]
-        },
-        {
-          "category": "storage",
-          "resourceName": "plateletStorage",
           "attributes": [
             "BucketName"
-          ]
+          ],
+          "category": "storage",
+          "resourceName": "plateletStorage"
         }
-      ]
+      ],
+      "providerPlugin": "awscloudformation",
+      "service": "Lambda"
     },
     "plateletProfilePictureResolver": {
       "build": true,
-      "providerPlugin": "awscloudformation",
-      "service": "Lambda",
       "dependsOn": [
         {
-          "category": "storage",
-          "resourceName": "plateletStorage",
           "attributes": [
             "BucketName"
-          ]
+          ],
+          "category": "storage",
+          "resourceName": "plateletStorage"
         }
-      ]
+      ],
+      "providerPlugin": "awscloudformation",
+      "service": "Lambda"
+    },
+    "plateletProfilePictureUploadURLResolver": {
+      "build": true,
+      "dependsOn": [
+        {
+          "attributes": [
+            "GraphQLAPIIdOutput",
+            "GraphQLAPIEndpointOutput"
+          ],
+          "category": "api",
+          "resourceName": "platelet"
+        },
+        {
+          "attributes": [
+            "BucketName"
+          ],
+          "category": "storage",
+          "resourceName": "plateletStorage"
+        }
+      ],
+      "providerPlugin": "awscloudformation",
+      "service": "Lambda"
     },
     "plateletSendUserFeedback": {
       "build": true,
+      "dependsOn": [],
       "providerPlugin": "awscloudformation",
-      "service": "Lambda",
-      "dependsOn": []
+      "service": "Lambda"
     }
   },
   "geo": {
     "plateletPlace": {
-      "isDefault": true,
-      "providerPlugin": "awscloudformation",
-      "service": "PlaceIndex",
+      "accessType": "AuthorizedUsers",
       "dataProvider": "HERE",
       "dataSourceIntendedUse": "SingleUse",
-      "accessType": "AuthorizedUsers",
       "dependsOn": [
         {
-          "category": "auth",
-          "resourceName": "platelet61a0ac07",
           "attributes": [
             "UserPoolId"
-          ]
+          ],
+          "category": "auth",
+          "resourceName": "platelet61a0ac07"
+        }
+      ],
+      "isDefault": true,
+      "providerPlugin": "awscloudformation",
+      "service": "PlaceIndex"
+    }
+  },
+  "hosting": {
+    "amplifyhosting": {
+      "providerPlugin": "awscloudformation",
+      "service": "amplifyhosting",
+      "type": "manual"
+    }
+  },
+  "parameters": {
+    "AMPLIFY_function_PlateletTaskResolvers_deploymentBucketName": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "PlateletTaskResolvers"
+        }
+      ]
+    },
+    "AMPLIFY_function_PlateletTaskResolvers_s3Key": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "PlateletTaskResolvers"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletAddNewTenant_deploymentBucketName": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletAddNewTenant"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletAddNewTenant_plateletDomainName": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletAddNewTenant"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletAddNewTenant_plateletWelcomeEmail": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletAddNewTenant"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletAddNewTenant_s3Key": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletAddNewTenant"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletAdminAddNewUser_deploymentBucketName": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletAdminAddNewUser"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletAdminAddNewUser_plateletDomainName": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletAdminAddNewUser"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletAdminAddNewUser_plateletWelcomeEmail": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletAdminAddNewUser"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletAdminAddNewUser_s3Key": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletAdminAddNewUser"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletAdminChangeUserRoles_deploymentBucketName": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletAdminChangeUserRoles"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletAdminChangeUserRoles_s3Key": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletAdminChangeUserRoles"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletImageResize_deploymentBucketName": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletImageResize"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletImageResize_resizeHeight": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletImageResize"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletImageResize_resizeWidth": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletImageResize"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletImageResize_s3Key": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletImageResize"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletImageResize_thumbnailHeight": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletImageResize"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletImageResize_thumbnailWidth": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletImageResize"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletProfilePictureResolver_deploymentBucketName": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletProfilePictureResolver"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletProfilePictureResolver_s3Key": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletProfilePictureResolver"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletProfilePictureUploadURLResolver_deploymentBucketName": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletProfilePictureUploadURLResolver"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletProfilePictureUploadURLResolver_s3Key": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletProfilePictureUploadURLResolver"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletSendUserFeedback_deploymentBucketName": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletSendUserFeedback"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletSendUserFeedback_plateletSendToEmailAddress": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletSendUserFeedback"
+        }
+      ]
+    },
+    "AMPLIFY_function_plateletSendUserFeedback_s3Key": {
+      "usedBy": [
+        {
+          "category": "function",
+          "resourceName": "plateletSendUserFeedback"
+        }
+      ]
+    },
+    "AMPLIFY_hosting_amplifyhosting_appId": {
+      "usedBy": [
+        {
+          "category": "hosting",
+          "resourceName": "amplifyhosting"
+        }
+      ]
+    },
+    "AMPLIFY_hosting_amplifyhosting_type": {
+      "usedBy": [
+        {
+          "category": "hosting",
+          "resourceName": "amplifyhosting"
         }
       ]
     }
   },
   "storage": {
     "plateletStorage": {
-      "service": "S3",
-      "providerPlugin": "awscloudformation",
       "dependsOn": [
         {
-          "category": "auth",
-          "resourceName": "platelet61a0ac07",
           "attributes": [
             "UserPoolId"
-          ]
+          ],
+          "category": "auth",
+          "resourceName": "platelet61a0ac07"
         },
         {
-          "category": "auth",
-          "resourceName": "userPoolGroups",
           "attributes": [
             "SUPERGroupRole"
-          ]
+          ],
+          "category": "auth",
+          "resourceName": "userPoolGroups"
         },
         {
-          "category": "auth",
-          "resourceName": "userPoolGroups",
           "attributes": [
             "USERGroupRole"
-          ]
+          ],
+          "category": "auth",
+          "resourceName": "userPoolGroups"
         },
         {
-          "category": "auth",
-          "resourceName": "userPoolGroups",
           "attributes": [
             "ADMINGroupRole"
-          ]
+          ],
+          "category": "auth",
+          "resourceName": "userPoolGroups"
         },
         {
-          "category": "auth",
-          "resourceName": "userPoolGroups",
           "attributes": [
             "COORDINATORGroupRole"
-          ]
+          ],
+          "category": "auth",
+          "resourceName": "userPoolGroups"
         },
         {
-          "category": "auth",
-          "resourceName": "userPoolGroups",
           "attributes": [
             "RIDERGroupRole"
-          ]
+          ],
+          "category": "auth",
+          "resourceName": "userPoolGroups"
         }
-      ]
-    }
-  },
-  "hosting": {
-    "amplifyhosting": {
-      "service": "amplifyhosting",
+      ],
       "providerPlugin": "awscloudformation",
-      "type": "manual"
+      "service": "S3"
     }
-  },
-  "custom": {}
+  }
 }

--- a/amplify/backend/function/PlateletTaskResolvers/PlateletTaskResolvers-cloudformation-template.json
+++ b/amplify/backend/function/PlateletTaskResolvers/PlateletTaskResolvers-cloudformation-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.4.0\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
+  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.6.2\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
   "Parameters": {
     "CloudWatchRule": {
       "Type": "String",
@@ -188,6 +188,14 @@
     "LambdaExecutionRole": {
       "Value": {
         "Ref": "LambdaExecutionRole"
+      }
+    },
+    "LambdaExecutionRoleArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "LambdaExecutionRole",
+          "Arn"
+        ]
       }
     }
   }

--- a/amplify/backend/function/plateletAddNewTenant/plateletAddNewTenant-cloudformation-template.json
+++ b/amplify/backend/function/plateletAddNewTenant/plateletAddNewTenant-cloudformation-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.4.0\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
+  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.6.2\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
   "Parameters": {
     "CloudWatchRule": {
       "Type": "String",
@@ -422,6 +422,14 @@
     "LambdaExecutionRole": {
       "Value": {
         "Ref": "LambdaExecutionRole"
+      }
+    },
+    "LambdaExecutionRoleArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "LambdaExecutionRole",
+          "Arn"
+        ]
       }
     }
   }

--- a/amplify/backend/function/plateletAdminAddNewUser/plateletAdminAddNewUser-cloudformation-template.json
+++ b/amplify/backend/function/plateletAdminAddNewUser/plateletAdminAddNewUser-cloudformation-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.4.0\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
+  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.6.2\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
   "Parameters": {
     "CloudWatchRule": {
       "Type": "String",
@@ -431,6 +431,14 @@
     "LambdaExecutionRole": {
       "Value": {
         "Ref": "LambdaExecutionRole"
+      }
+    },
+    "LambdaExecutionRoleArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "LambdaExecutionRole",
+          "Arn"
+        ]
       }
     }
   }

--- a/amplify/backend/function/plateletAdminChangeUserRoles/plateletAdminChangeUserRoles-cloudformation-template.json
+++ b/amplify/backend/function/plateletAdminChangeUserRoles/plateletAdminChangeUserRoles-cloudformation-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.4.0\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
+  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.6.2\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
   "Parameters": {
     "CloudWatchRule": {
       "Type": "String",
@@ -341,6 +341,14 @@
     "LambdaExecutionRole": {
       "Value": {
         "Ref": "LambdaExecutionRole"
+      }
+    },
+    "LambdaExecutionRoleArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "LambdaExecutionRole",
+          "Arn"
+        ]
       }
     }
   }

--- a/amplify/backend/function/plateletImageResize/plateletImageResize-cloudformation-template.json
+++ b/amplify/backend/function/plateletImageResize/plateletImageResize-cloudformation-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.4.0\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
+  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.6.2\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
   "Parameters": {
     "CloudWatchRule": {
       "Type": "String",
@@ -306,6 +306,14 @@
     "LambdaExecutionRole": {
       "Value": {
         "Ref": "LambdaExecutionRole"
+      }
+    },
+    "LambdaExecutionRoleArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "LambdaExecutionRole",
+          "Arn"
+        ]
       }
     }
   }

--- a/amplify/backend/function/plateletProfilePictureResolver/plateletProfilePictureResolver-cloudformation-template.json
+++ b/amplify/backend/function/plateletProfilePictureResolver/plateletProfilePictureResolver-cloudformation-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.4.0\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
+  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.6.2\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
   "Parameters": {
     "CloudWatchRule": {
       "Type": "String",
@@ -252,6 +252,14 @@
     "LambdaExecutionRole": {
       "Value": {
         "Ref": "LambdaExecutionRole"
+      }
+    },
+    "LambdaExecutionRoleArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "LambdaExecutionRole",
+          "Arn"
+        ]
       }
     }
   }

--- a/amplify/backend/function/plateletProfilePictureUploadURLResolver/plateletProfilePictureUploadURLResolver-cloudformation-template.json
+++ b/amplify/backend/function/plateletProfilePictureUploadURLResolver/plateletProfilePictureUploadURLResolver-cloudformation-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.4.0\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
+  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.6.2\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
   "Parameters": {
     "CloudWatchRule": {
       "Type": "String",
@@ -294,6 +294,14 @@
     "LambdaExecutionRole": {
       "Value": {
         "Ref": "LambdaExecutionRole"
+      }
+    },
+    "LambdaExecutionRoleArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "LambdaExecutionRole",
+          "Arn"
+        ]
       }
     }
   }

--- a/amplify/backend/function/plateletSendUserFeedback/plateletSendUserFeedback-cloudformation-template.json
+++ b/amplify/backend/function/plateletSendUserFeedback/plateletSendUserFeedback-cloudformation-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.4.0\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
+  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.6.2\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
   "Parameters": {
     "CloudWatchRule": {
       "Type": "String",
@@ -221,6 +221,14 @@
     "LambdaExecutionRole": {
       "Value": {
         "Ref": "LambdaExecutionRole"
+      }
+    },
+    "LambdaExecutionRoleArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "LambdaExecutionRole",
+          "Arn"
+        ]
       }
     }
   }

--- a/amplify/backend/geo/plateletPlace/plateletPlace-cloudformation-template.json
+++ b/amplify/backend/geo/plateletPlace/plateletPlace-cloudformation-template.json
@@ -326,5 +326,5 @@
       }
     }
   },
-  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.4.0\",\"stackType\":\"geo-PlaceIndex\",\"metadata\":{}}"
+  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.6.2\",\"stackType\":\"geo-PlaceIndex\",\"metadata\":{}}"
 }

--- a/amplify/backend/hosting/amplifyhosting/amplifyhosting-template.json
+++ b/amplify/backend/hosting/amplifyhosting/amplifyhosting-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.4.0\",\"stackType\":\"hosting-amplifyhosting\",\"metadata\":{}}",
+  "Description": "{\"createdOn\":\"Linux\",\"createdBy\":\"Amplify\",\"createdWith\":\"10.6.2\",\"stackType\":\"hosting-amplifyhosting\",\"metadata\":{}}",
   "Parameters": {
     "env": {
       "Type": "String"

--- a/amplify/backend/types/amplify-dependent-resources-ref.d.ts
+++ b/amplify/backend/types/amplify-dependent-resources-ref.d.ts
@@ -1,90 +1,98 @@
 export type AmplifyDependentResourcesAttributes = {
-    "auth": {
-        "platelet61a0ac07": {
-            "IdentityPoolId": "string",
-            "IdentityPoolName": "string",
-            "UserPoolId": "string",
-            "UserPoolArn": "string",
-            "UserPoolName": "string",
-            "AppClientIDWeb": "string",
-            "AppClientID": "string",
-            "CreatedSNSRole": "string"
-        },
-        "userPoolGroups": {
-            "SUPERGroupRole": "string",
-            "ADMINGroupRole": "string",
-            "COORDINATORGroupRole": "string",
-            "RIDERGroupRole": "string",
-            "USERGroupRole": "string"
-        }
-    },
-    "api": {
-        "platelet": {
-            "GraphQLAPIIdOutput": "string",
-            "GraphQLAPIEndpointOutput": "string"
-        }
-    },
-    "function": {
-        "PlateletTaskResolvers": {
-            "Name": "string",
-            "Arn": "string",
-            "Region": "string",
-            "LambdaExecutionRole": "string"
-        },
-        "plateletImageResize": {
-            "Name": "string",
-            "Arn": "string",
-            "Region": "string",
-            "LambdaExecutionRole": "string"
-        },
-        "plateletAdminAddNewUser": {
-            "Name": "string",
-            "Arn": "string",
-            "Region": "string",
-            "LambdaExecutionRole": "string"
-        },
-        "plateletAddNewTenant": {
-            "Name": "string",
-            "Arn": "string",
-            "Region": "string",
-            "LambdaExecutionRole": "string"
-        },
-        "plateletAdminChangeUserRoles": {
-            "Name": "string",
-            "Arn": "string",
-            "Region": "string",
-            "LambdaExecutionRole": "string"
-        },
-        "plateletProfilePictureUploadURLResolver": {
-            "Name": "string",
-            "Arn": "string",
-            "Region": "string",
-            "LambdaExecutionRole": "string"
-        },
-        "plateletProfilePictureResolver": {
-            "Name": "string",
-            "Arn": "string",
-            "Region": "string",
-            "LambdaExecutionRole": "string"
-        },
-        "plateletSendUserFeedback": {
-            "Name": "string",
-            "Arn": "string",
-            "Region": "string",
-            "LambdaExecutionRole": "string"
-        }
-    },
-    "geo": {
-        "plateletPlace": {
-            "Name": "string",
-            "Region": "string",
-            "Arn": "string"
-        }
-    },
-    "storage": {
-        "plateletStorage": {
-            "BucketName": "string",
-            "Region": "string"
-        }
+  "api": {
+    "platelet": {
+      "GraphQLAPIEndpointOutput": "string",
+      "GraphQLAPIIdOutput": "string"
     }
+  },
+  "auth": {
+    "platelet61a0ac07": {
+      "AppClientID": "string",
+      "AppClientIDWeb": "string",
+      "CreatedSNSRole": "string",
+      "IdentityPoolId": "string",
+      "IdentityPoolName": "string",
+      "UserPoolArn": "string",
+      "UserPoolId": "string",
+      "UserPoolName": "string"
+    },
+    "userPoolGroups": {
+      "ADMINGroupRole": "string",
+      "COORDINATORGroupRole": "string",
+      "RIDERGroupRole": "string",
+      "SUPERGroupRole": "string",
+      "USERGroupRole": "string"
+    }
+  },
+  "function": {
+    "PlateletTaskResolvers": {
+      "Arn": "string",
+      "LambdaExecutionRole": "string",
+      "LambdaExecutionRoleArn": "string",
+      "Name": "string",
+      "Region": "string"
+    },
+    "plateletAddNewTenant": {
+      "Arn": "string",
+      "LambdaExecutionRole": "string",
+      "LambdaExecutionRoleArn": "string",
+      "Name": "string",
+      "Region": "string"
+    },
+    "plateletAdminAddNewUser": {
+      "Arn": "string",
+      "LambdaExecutionRole": "string",
+      "LambdaExecutionRoleArn": "string",
+      "Name": "string",
+      "Region": "string"
+    },
+    "plateletAdminChangeUserRoles": {
+      "Arn": "string",
+      "LambdaExecutionRole": "string",
+      "LambdaExecutionRoleArn": "string",
+      "Name": "string",
+      "Region": "string"
+    },
+    "plateletImageResize": {
+      "Arn": "string",
+      "LambdaExecutionRole": "string",
+      "LambdaExecutionRoleArn": "string",
+      "Name": "string",
+      "Region": "string"
+    },
+    "plateletProfilePictureResolver": {
+      "Arn": "string",
+      "LambdaExecutionRole": "string",
+      "LambdaExecutionRoleArn": "string",
+      "Name": "string",
+      "Region": "string"
+    },
+    "plateletProfilePictureUploadURLResolver": {
+      "Arn": "string",
+      "LambdaExecutionRole": "string",
+      "LambdaExecutionRoleArn": "string",
+      "Name": "string",
+      "Region": "string"
+    },
+    "plateletSendUserFeedback": {
+      "Arn": "string",
+      "LambdaExecutionRole": "string",
+      "LambdaExecutionRoleArn": "string",
+      "Name": "string",
+      "Region": "string"
+    }
+  },
+  "geo": {
+    "plateletPlace": {
+      "Arn": "string",
+      "Name": "string",
+      "Region": "string"
+    }
+  },
+  "storage": {
+    "plateletStorage": {
+      "BucketName": "string",
+      "Region": "string"
+    }
+  }
 }

--- a/amplify/hooks/README.md
+++ b/amplify/hooks/README.md
@@ -1,0 +1,7 @@
+# Command Hooks
+
+Command hooks can be used to run custom scripts upon Amplify CLI lifecycle events like pre-push, post-add-function, etc.
+
+To get started, add your script files based on the expected naming convention in this directory.
+
+Learn more about the script file naming convention, hook parameters, third party dependencies, and advanced configurations at https://docs.amplify.aws/cli/usage/command-hooks

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -380,6 +380,7 @@ export const createUser = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -568,6 +569,7 @@ export const updateUser = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -756,6 +758,7 @@ export const deleteUser = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2008,6 +2011,7 @@ export const createLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2037,6 +2041,7 @@ export const createLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2066,6 +2071,7 @@ export const createLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2228,6 +2234,7 @@ export const updateLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2257,6 +2264,7 @@ export const updateLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2286,6 +2294,7 @@ export const updateLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2448,6 +2457,7 @@ export const deleteLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2477,6 +2487,7 @@ export const deleteLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2506,6 +2517,7 @@ export const deleteLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2929,6 +2941,7 @@ export const createTask = /* GraphQL */ `
         startedAt
       }
       status
+      isRiderUsingOwnVehicle
       createdAt
       updatedAt
       _version
@@ -3322,6 +3335,7 @@ export const updateTask = /* GraphQL */ `
         startedAt
       }
       status
+      isRiderUsingOwnVehicle
       createdAt
       updatedAt
       _version
@@ -3715,6 +3729,7 @@ export const deleteTask = /* GraphQL */ `
         startedAt
       }
       status
+      isRiderUsingOwnVehicle
       createdAt
       updatedAt
       _version
@@ -3870,6 +3885,7 @@ export const createTaskAssignee = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -4101,6 +4117,7 @@ export const updateTaskAssignee = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -4332,6 +4349,7 @@ export const deleteTaskAssignee = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -4964,6 +4982,7 @@ export const createDeliverable = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -5165,6 +5184,7 @@ export const updateDeliverable = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -5366,6 +5386,7 @@ export const deleteDeliverable = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -5631,6 +5652,7 @@ export const registerUser = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -5907,6 +5929,7 @@ export const updateUserRoles = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -292,6 +292,7 @@ export const getUser = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -1436,6 +1437,7 @@ export const getLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -1465,6 +1467,7 @@ export const getLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -1494,6 +1497,7 @@ export const getLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2094,6 +2098,7 @@ export const getTask = /* GraphQL */ `
         startedAt
       }
       status
+      isRiderUsingOwnVehicle
       createdAt
       updatedAt
       _version
@@ -2247,6 +2252,7 @@ export const listTasks = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -2409,6 +2415,7 @@ export const syncTasks = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -2573,6 +2580,7 @@ export const tasksByStatus = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -2728,6 +2736,7 @@ export const getTaskAssignee = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -2842,6 +2851,7 @@ export const listTaskAssignees = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2916,6 +2926,7 @@ export const syncTaskAssignees = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -3403,6 +3414,7 @@ export const getDeliverable = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -3483,6 +3495,7 @@ export const listDeliverables = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -3558,6 +3571,7 @@ export const syncDeliverables = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version

--- a/src/graphql/subscriptions.js
+++ b/src/graphql/subscriptions.js
@@ -368,6 +368,7 @@ export const onCreateUser = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -553,6 +554,7 @@ export const onUpdateUser = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -738,6 +740,7 @@ export const onDeleteUser = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -1972,6 +1975,7 @@ export const onCreateLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2001,6 +2005,7 @@ export const onCreateLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2030,6 +2035,7 @@ export const onCreateLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2189,6 +2195,7 @@ export const onUpdateLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2218,6 +2225,7 @@ export const onUpdateLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2247,6 +2255,7 @@ export const onUpdateLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2406,6 +2415,7 @@ export const onDeleteLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2435,6 +2445,7 @@ export const onDeleteLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2464,6 +2475,7 @@ export const onDeleteLocation = /* GraphQL */ `
           riderResponsibility
           priority
           status
+          isRiderUsingOwnVehicle
           createdAt
           updatedAt
           _version
@@ -2884,6 +2896,7 @@ export const onCreateTask = /* GraphQL */ `
         startedAt
       }
       status
+      isRiderUsingOwnVehicle
       createdAt
       updatedAt
       _version
@@ -3274,6 +3287,7 @@ export const onUpdateTask = /* GraphQL */ `
         startedAt
       }
       status
+      isRiderUsingOwnVehicle
       createdAt
       updatedAt
       _version
@@ -3664,6 +3678,7 @@ export const onDeleteTask = /* GraphQL */ `
         startedAt
       }
       status
+      isRiderUsingOwnVehicle
       createdAt
       updatedAt
       _version
@@ -3818,6 +3833,7 @@ export const onCreateTaskAssignee = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -4048,6 +4064,7 @@ export const onUpdateTaskAssignee = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -4278,6 +4295,7 @@ export const onDeleteTaskAssignee = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -4906,6 +4924,7 @@ export const onCreateDeliverable = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -5106,6 +5125,7 @@ export const onUpdateDeliverable = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version
@@ -5306,6 +5326,7 @@ export const onDeleteDeliverable = /* GraphQL */ `
           startedAt
         }
         status
+        isRiderUsingOwnVehicle
         createdAt
         updatedAt
         _version

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -375,6 +375,7 @@ type EagerTask = {
   readonly deliverables?: (Deliverable | null)[] | null;
   readonly comments?: (Comment | null)[] | null;
   readonly status?: TaskStatus | keyof typeof TaskStatus | null;
+  readonly isRiderUsingOwnVehicle?: number | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }
@@ -402,6 +403,7 @@ type LazyTask = {
   readonly deliverables: AsyncCollection<Deliverable>;
   readonly comments: AsyncCollection<Comment>;
   readonly status?: TaskStatus | keyof typeof TaskStatus | null;
+  readonly isRiderUsingOwnVehicle?: number | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }

--- a/src/models/schema.js
+++ b/src/models/schema.js
@@ -954,6 +954,13 @@ export const schema = {
                     "isRequired": false,
                     "attributes": []
                 },
+                "isRiderUsingOwnVehicle": {
+                    "name": "isRiderUsingOwnVehicle",
+                    "isArray": false,
+                    "type": "Int",
+                    "isRequired": false,
+                    "attributes": []
+                },
                 "createdAt": {
                     "name": "createdAt",
                     "isArray": false,
@@ -2207,6 +2214,6 @@ export const schema = {
             }
         }
     },
-    "codegenVersion": "3.3.2",
-    "version": "bb2e35b6475bd0ff1a48255f28cdd761"
+    "codegenVersion": "3.3.5",
+    "version": "3c3c2097a8699496ece95b504d3fb046"
 };

--- a/src/scenes/Reports/utilities/generateReport.js
+++ b/src/scenes/Reports/utilities/generateReport.js
@@ -8,6 +8,7 @@ import { writeToString } from "@fast-csv/format";
 const taskFields = {
     id: "",
     createdAt: "",
+    isRiderUsingOwnVehicle: "",
     timeOfCall: "",
     priority: "",
     status: "",
@@ -265,6 +266,7 @@ export default async function generateReport(userId, role, days) {
     );
     finalTasks = await Promise.all(
         finalTasks.map(async (t) => {
+            const isRiderUsingOwnVehicle = !!t.isRiderUsingOwnVehicle;
             const comments = commentsAll.filter((c) => c.parentId === t.id);
             const items = deliverables.filter(
                 (d) => d.task && d.task.id === t.id
@@ -272,7 +274,7 @@ export default async function generateReport(userId, role, days) {
             const assignees = assignments.filter(
                 (assignment) => assignment.task && assignment.task.id === t.id
             );
-            return { ...t, comments, items, assignees };
+            return { ...t, comments, items, assignees, isRiderUsingOwnVehicle };
         })
     );
     return generateCSV(finalTasks);

--- a/src/scenes/Reports/utilities/generateReports.test.js
+++ b/src/scenes/Reports/utilities/generateReports.test.js
@@ -80,6 +80,7 @@ describe("generateReports", () => {
                     telephoneNumber: uuidv4(),
                 },
                 priority: priorities.medium,
+                isRiderUsingOwnVehicle: 0,
                 pickUpLocation: pickUpLocation1,
                 dropOffLocation: dropOffLocation1,
                 riderResponsibility: uuidv4(),
@@ -97,6 +98,7 @@ describe("generateReports", () => {
                     telephoneNumber: uuidv4(),
                 },
                 priority: priorities.medium,
+                isRiderUsingOwnVehicle: 1,
                 pickUpLocation: pickUpLocation2,
                 dropOffLocation: dropOffLocation2,
                 riderResponsibility: uuidv4(),
@@ -165,69 +167,69 @@ describe("generateReports", () => {
             )
         );
         // I don't know why I did this
-        const expected = `id,createdAt,timeOfCall,priority,status,riderResponsibility,timePickedUp,timeDroppedOff,timeRiderHome,pickUpLocation_ward,pickUpLocation_line1,pickUpLocation_line2,pickUpLocation_line3,pickUpLocation_town,pickUpLocation_county,pickUpLocation_state,pickUpLocation_country,pickUpLocation_postcode,dropOffLocation_ward,dropOffLocation_line1,dropOffLocation_line2,dropOffLocation_line3,dropOffLocation_town,dropOffLocation_county,dropOffLocation_state,dropOffLocation_country,dropOffLocation_postcode,requesterContact_name,requesterContact_telephoneNumber,comment_0_id,comment_0_createdAt,comment_0_author,comment_0_body,comment_1_id,comment_1_createdAt,comment_1_author,comment_1_body,item_0_id,item_0_createdAt,item_0_label,item_0_count,item_0_unit,assignee_0_id,assignee_0_createdAt,assignee_0_displayName,assignee_0_name,assignee_0_role,assignee_1_id,assignee_1_createdAt,assignee_1_displayName,assignee_1_name,assignee_1_role
-${task1.id},${task1.createdAt || ""},${task1.timeOfCall},${task1.priority},${
-            task1.status
-        },${task1.riderResponsibility},${task1.timePickedUp},${
-            task1.timeDroppedOff
-        },${task1.timeRiderHome},${task1.pickUpLocation.ward},${
-            task1.pickUpLocation.line1
-        },${task1.pickUpLocation.line2},${task1.pickUpLocation.line3},${
-            task1.pickUpLocation.town
-        },${task1.pickUpLocation.county},${task1.pickUpLocation.state},${
-            task1.pickUpLocation.country
-        },${task1.pickUpLocation.postcode},${task1.dropOffLocation.ward},${
-            task1.dropOffLocation.line1
-        },${task1.dropOffLocation.line2},${task1.dropOffLocation.line3},${
-            task1.dropOffLocation.town
-        },${task1.dropOffLocation.county},${task1.dropOffLocation.state},${
-            task1.dropOffLocation.country
-        },${task1.dropOffLocation.postcode},${task1.requesterContact.name},${
-            task1.requesterContact.telephoneNumber
-        },${comment1.id},${comment1.createdAt || ""},${
-            comment1.author.displayName
-        },${comment1.body},${comment2.id},${comment2.createdAt || ""},${
-            comment2.author.displayName
-        },${comment2.body},${item1.id},${item1.createdAt || ""},${
-            item1.deliverableType.label
-        },${item1.count},${item1.unit},${coordAssignee1.id},${
-            coordAssignee1.createdAt || ""
-        },${coordAssignee1.assignee.displayName},${
-            coordAssignee1.assignee.name
-        },${coordAssignee1.role},${riderAssignee1.id},${
-            riderAssignee1.createdAt || ""
-        },${riderAssignee1.assignee.displayName},${
-            riderAssignee1.assignee.name
-        },${riderAssignee1.role}
-${task2.id},${task2.createdAt || ""},${task2.timeOfCall},${task2.priority},${
-            task2.status
-        },${task2.riderResponsibility},${task2.timePickedUp},${
-            task2.timeDroppedOff
-        },${task2.timeRiderHome},${task2.pickUpLocation.ward},${
-            task2.pickUpLocation.line1
-        },${task2.pickUpLocation.line2},${task2.pickUpLocation.line3},${
-            task2.pickUpLocation.town
-        },${task2.pickUpLocation.county},${task2.pickUpLocation.state},${
-            task2.pickUpLocation.country
-        },${task2.pickUpLocation.postcode},${task2.dropOffLocation.ward},${
-            task2.dropOffLocation.line1
-        },${task2.dropOffLocation.line2},${task2.dropOffLocation.line3},${
-            task2.dropOffLocation.town
-        },${task2.dropOffLocation.county},${task2.dropOffLocation.state},${
-            task2.dropOffLocation.country
-        },${task2.dropOffLocation.postcode},${task2.requesterContact.name},${
-            task2.requesterContact.telephoneNumber
-        },,,,,,,,,${item2.id},${item2.createdAt || ""},${
-            item2.deliverableType.label
-        },${item2.count},${item2.unit},${coordAssignee2.id},${
-            coordAssignee2.createdAt || ""
-        },${coordAssignee2.assignee.displayName},${
-            coordAssignee2.assignee.name
-        },${coordAssignee2.role},${riderAssignee2.id},${
-            riderAssignee2.createdAt || ""
-        },${riderAssignee2.assignee.displayName},${
-            riderAssignee2.assignee.name
-        },${riderAssignee2.role}`;
+        const expected = `id,createdAt,isRiderUsingOwnVehicle,timeOfCall,priority,status,riderResponsibility,timePickedUp,timeDroppedOff,timeRiderHome,pickUpLocation_ward,pickUpLocation_line1,pickUpLocation_line2,pickUpLocation_line3,pickUpLocation_town,pickUpLocation_county,pickUpLocation_state,pickUpLocation_country,pickUpLocation_postcode,dropOffLocation_ward,dropOffLocation_line1,dropOffLocation_line2,dropOffLocation_line3,dropOffLocation_town,dropOffLocation_county,dropOffLocation_state,dropOffLocation_country,dropOffLocation_postcode,requesterContact_name,requesterContact_telephoneNumber,comment_0_id,comment_0_createdAt,comment_0_author,comment_0_body,comment_1_id,comment_1_createdAt,comment_1_author,comment_1_body,item_0_id,item_0_createdAt,item_0_label,item_0_count,item_0_unit,assignee_0_id,assignee_0_createdAt,assignee_0_displayName,assignee_0_name,assignee_0_role,assignee_1_id,assignee_1_createdAt,assignee_1_displayName,assignee_1_name,assignee_1_role
+${task1.id},${task1.createdAt || ""},${!!task1.isRiderUsingOwnVehicle},${
+            task1.timeOfCall
+        },${task1.priority},${task1.status},${task1.riderResponsibility},${
+            task1.timePickedUp
+        },${task1.timeDroppedOff},${task1.timeRiderHome},${
+            task1.pickUpLocation.ward
+        },${task1.pickUpLocation.line1},${task1.pickUpLocation.line2},${
+            task1.pickUpLocation.line3
+        },${task1.pickUpLocation.town},${task1.pickUpLocation.county},${
+            task1.pickUpLocation.state
+        },${task1.pickUpLocation.country},${task1.pickUpLocation.postcode},${
+            task1.dropOffLocation.ward
+        },${task1.dropOffLocation.line1},${task1.dropOffLocation.line2},${
+            task1.dropOffLocation.line3
+        },${task1.dropOffLocation.town},${task1.dropOffLocation.county},${
+            task1.dropOffLocation.state
+        },${task1.dropOffLocation.country},${task1.dropOffLocation.postcode},${
+            task1.requesterContact.name
+        },${task1.requesterContact.telephoneNumber},${comment1.id},${
+            comment1.createdAt || ""
+        },${comment1.author.displayName},${comment1.body},${comment2.id},${
+            comment2.createdAt || ""
+        },${comment2.author.displayName},${comment2.body},${item1.id},${
+            item1.createdAt || ""
+        },${item1.deliverableType.label},${item1.count},${item1.unit},${
+            coordAssignee1.id
+        },${coordAssignee1.createdAt || ""},${
+            coordAssignee1.assignee.displayName
+        },${coordAssignee1.assignee.name},${coordAssignee1.role},${
+            riderAssignee1.id
+        },${riderAssignee1.createdAt || ""},${
+            riderAssignee1.assignee.displayName
+        },${riderAssignee1.assignee.name},${riderAssignee1.role}
+${task2.id},${task2.createdAt || ""},${!!task2.isRiderUsingOwnVehicle},${
+            task2.timeOfCall
+        },${task2.priority},${task2.status},${task2.riderResponsibility},${
+            task2.timePickedUp
+        },${task2.timeDroppedOff},${task2.timeRiderHome},${
+            task2.pickUpLocation.ward
+        },${task2.pickUpLocation.line1},${task2.pickUpLocation.line2},${
+            task2.pickUpLocation.line3
+        },${task2.pickUpLocation.town},${task2.pickUpLocation.county},${
+            task2.pickUpLocation.state
+        },${task2.pickUpLocation.country},${task2.pickUpLocation.postcode},${
+            task2.dropOffLocation.ward
+        },${task2.dropOffLocation.line1},${task2.dropOffLocation.line2},${
+            task2.dropOffLocation.line3
+        },${task2.dropOffLocation.town},${task2.dropOffLocation.county},${
+            task2.dropOffLocation.state
+        },${task2.dropOffLocation.country},${task2.dropOffLocation.postcode},${
+            task2.requesterContact.name
+        },${task2.requesterContact.telephoneNumber},,,,,,,,,${item2.id},${
+            item2.createdAt || ""
+        },${item2.deliverableType.label},${item2.count},${item2.unit},${
+            coordAssignee2.id
+        },${coordAssignee2.createdAt || ""},${
+            coordAssignee2.assignee.displayName
+        },${coordAssignee2.assignee.name},${coordAssignee2.role},${
+            riderAssignee2.id
+        },${riderAssignee2.createdAt || ""},${
+            riderAssignee2.assignee.displayName
+        },${riderAssignee2.assignee.name},${riderAssignee2.role}`;
 
         const result = await generateReport(
             whoami.id,

--- a/src/scenes/Task/components/TaskAssignees.tsx
+++ b/src/scenes/Task/components/TaskAssignees.tsx
@@ -128,6 +128,10 @@ const TaskAssignees: React.FC<TaskAssigneesProps> = ({
                             </Grid>
                             <Grid item>
                                 <Switch
+                                    inputProps={{
+                                        "aria-label":
+                                            "rider using own vehicle?",
+                                    }}
                                     disabled={disableUsingOwnVehicleSwitch}
                                     onChange={onChangeRiderUsingOwnVehicle}
                                     checked={usingOwnVehicle}

--- a/src/scenes/Task/components/TaskAssignees.tsx
+++ b/src/scenes/Task/components/TaskAssignees.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Typography from "@mui/material/Typography";
-import { Divider, Grid, Stack } from "@mui/material";
+import { Divider, Grid, Stack, Switch } from "@mui/material";
 import { userRoles } from "../../../apiConsts";
 import UserChip from "../../../components/UserChip";
 import { sortByCreatedTime } from "../../../utilities";
@@ -13,22 +13,34 @@ type TaskAssigneesProps = {
     assignees: models.TaskAssignee[];
     onRemove?: (arg0: string) => void;
     disabled?: boolean;
+    onChangeRiderUsingOwnVehicle?: () => void;
+    usingOwnVehicle?: boolean;
+    disableUsingOwnVehicleSwitch?: boolean;
 };
 
-const TaskAssignees: React.FC<TaskAssigneesProps> = (props) => {
+const TaskAssignees: React.FC<TaskAssigneesProps> = ({
+    assignees,
+    onRemove = () => {},
+    disabled = false,
+    onChangeRiderUsingOwnVehicle = () => {},
+    usingOwnVehicle = false,
+    disableUsingOwnVehicleSwitch = false,
+}) => {
     const whoami = useSelector(getWhoami);
     const [confirmRemoveId, setConfirmRemoveId] = React.useState<string | null>(
         null
     );
     const handleRemove = (assignment: models.TaskAssignee) => {
-        if (props.onRemove) {
+        if (onRemove) {
             if (assignment.assignee?.id === whoami.id) {
                 setConfirmRemoveId(assignment.id);
             } else {
-                props.onRemove(assignment.id);
+                onRemove(assignment.id);
             }
         }
     };
+
+    const hasRiders = assignees.some((a) => a.role === userRoles.rider);
 
     const confirmationSelfDeleteDialog = (
         <ConfirmationDialog
@@ -36,8 +48,7 @@ const TaskAssignees: React.FC<TaskAssigneesProps> = (props) => {
             onCancel={() => setConfirmRemoveId(null)}
             open={!!confirmRemoveId}
             onConfirmation={() => {
-                if (props.onRemove && confirmRemoveId)
-                    props.onRemove(confirmRemoveId);
+                if (onRemove && confirmRemoveId) onRemove(confirmRemoveId);
                 setConfirmRemoveId(null);
             }}
         >
@@ -52,7 +63,7 @@ const TaskAssignees: React.FC<TaskAssigneesProps> = (props) => {
 
     const mappedAssigneeContents = [userRoles.coordinator, userRoles.rider].map(
         (role) => {
-            const assignmentsUnsorted = props.assignees.filter(
+            const assignmentsUnsorted = assignees.filter(
                 (a) => a.role === role
             );
             const assignments = sortByCreatedTime(
@@ -86,7 +97,7 @@ const TaskAssignees: React.FC<TaskAssigneesProps> = (props) => {
                                         showResponsibility={
                                             role === userRoles.rider
                                         }
-                                        disabled={props.disabled}
+                                        disabled={disabled}
                                         user={user}
                                         onDelete={() =>
                                             handleRemove(assignment)
@@ -96,6 +107,34 @@ const TaskAssignees: React.FC<TaskAssigneesProps> = (props) => {
                             );
                         })}
                     </Grid>
+                    {hasRiders && role === userRoles.rider && (
+                        <Grid
+                            container
+                            alignItems="center"
+                            direction="row"
+                            spacing={1}
+                        >
+                            <Grid item>
+                                <Typography
+                                    sx={{
+                                        cursor: disableUsingOwnVehicleSwitch
+                                            ? "default"
+                                            : "pointer",
+                                    }}
+                                    onClick={onChangeRiderUsingOwnVehicle}
+                                >
+                                    Using own vehicle?
+                                </Typography>
+                            </Grid>
+                            <Grid item>
+                                <Switch
+                                    disabled={disableUsingOwnVehicleSwitch}
+                                    onChange={onChangeRiderUsingOwnVehicle}
+                                    checked={usingOwnVehicle}
+                                />
+                            </Grid>
+                        </Grid>
+                    )}
                     <Divider />
                 </>
             );
@@ -107,12 +146,6 @@ const TaskAssignees: React.FC<TaskAssigneesProps> = (props) => {
             {mappedAssigneeContents}
         </>
     );
-};
-
-TaskAssignees.defaultProps = {
-    assignees: [],
-    onRemove: () => {},
-    disabled: false,
 };
 
 export default TaskAssignees;


### PR DESCRIPTION
This feature is to satisfy the new requirement by Freewheelers to record if a rider is using their own vehicle or not.

I expect this feature to be temporary until proper support is added for recording full vehicle information against a job.


No toggle displayed until a rider is assigned.

![image](https://user-images.githubusercontent.com/32309223/216338330-40c02ed9-bd2d-4ca2-9e5b-fa862e704fdc.png)

Toggle appears once someone is assigned.

![image](https://user-images.githubusercontent.com/32309223/216338470-52b17cc2-7c4e-4b12-ba02-0290bac8db8c.png)

Non edit mode shows selection.

![image](https://user-images.githubusercontent.com/32309223/216338523-2eb6a0ee-7d17-4730-ab80-ffbbb73f1da1.png)

![image](https://user-images.githubusercontent.com/32309223/216338833-fadfd3b8-5ce2-4962-a2e4-cc98d537209b.png)


![image](https://user-images.githubusercontent.com/32309223/216338560-6280b955-7cb0-46eb-baac-290f94835365.png)

Data is recorded against the Task model itself and not on the assignment. It's never expected that more than one rider will be assigned to a job so this should work fine for now.

Final steps are to add the field to csv exports.