### PR TITLE
Swap out material makeStyles for tss-react makeStyles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
                 "seedrandom": "^3.0.5",
                 "socket.io-client": "^4.1.3",
                 "styled-components": "^5.3.1",
+                "tss-react": "^4.6.0",
                 "typescript": "^4.8.3",
                 "uuid": "^8.3.2",
                 "uuid-base62": "^0.1.0",
@@ -31727,6 +31728,26 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
             "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         },
+        "node_modules/tss-react": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-4.6.0.tgz",
+            "integrity": "sha512-GWIduTQpV2B5iEvVSDkYTjvtLi+irTckO5tR28vCYwIOzvgUcK/Gr9xZ/NuJY1Qdb0pasNda5lCecjSnzj1Y0A==",
+            "dependencies": {
+                "@emotion/cache": "*",
+                "@emotion/serialize": "*",
+                "@emotion/utils": "*"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.4.1",
+                "@emotion/server": "^11.4.0",
+                "react": "^16.8.0 || ^17.0.2 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/server": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/tsutils": {
             "version": "3.20.0",
             "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.20.0.tgz",
@@ -59302,6 +59323,16 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
             "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        },
+        "tss-react": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-4.6.0.tgz",
+            "integrity": "sha512-GWIduTQpV2B5iEvVSDkYTjvtLi+irTckO5tR28vCYwIOzvgUcK/Gr9xZ/NuJY1Qdb0pasNda5lCecjSnzj1Y0A==",
+            "requires": {
+                "@emotion/cache": "*",
+                "@emotion/serialize": "*",
+                "@emotion/utils": "*"
+            }
         },
         "tsutils": {
             "version": "3.20.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "seedrandom": "^3.0.5",
         "socket.io-client": "^4.1.3",
         "styled-components": "^5.3.1",
+        "tss-react": "^4.6.0",
         "typescript": "^4.8.3",
         "uuid": "^8.3.2",
         "uuid-base62": "^0.1.0",

--- a/src/components/Buttons.js
+++ b/src/components/Buttons.js
@@ -14,7 +14,7 @@ import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import AddCircleOutline from "@mui/icons-material/AddCircleOutline";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 
@@ -61,7 +61,7 @@ export function AddCircleButtonSmall(props) {
 }
 
 function SmallCirclePlusButton(props) {
-    const useStyles = makeStyles((theme) => ({
+    const useStyles = makeStyles()((theme) => ({
         button: {
             color: props.colour,
             width: theme.spacing(4),
@@ -72,7 +72,7 @@ function SmallCirclePlusButton(props) {
             height: theme.spacing(4),
         },
     }));
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <Tooltip title={props.tooltip}>
@@ -105,7 +105,7 @@ SmallCirclePlusButton.propTypes = {
 };
 
 function ArrowButton(props) {
-    const useStyles = makeStyles((theme) => ({
+    const useStyles = makeStyles()((theme) => ({
         button: {
             color: props.colour,
             width: theme.spacing(props.size),
@@ -116,7 +116,7 @@ function ArrowButton(props) {
             height: theme.spacing(props.size),
         },
     }));
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     let arrowIcon = <></>;
     if (props.direction === "up")

--- a/src/components/CardItem.js
+++ b/src/components/CardItem.js
@@ -1,9 +1,9 @@
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import { Stack, Typography } from "@mui/material";
 import React from "react";
 import PropTypes from "prop-types";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     titleText: {
         fontSize: 14,
     },
@@ -15,7 +15,7 @@ const useStyles = makeStyles({
 });
 
 function CardItem(props) {
-    const classes = useStyles();
+    const { classes } = useStyles();
     return (
         <Stack
             sx={{ width: props.width }}

--- a/src/components/ClickableTextField.js
+++ b/src/components/ClickableTextField.js
@@ -1,11 +1,10 @@
 import React, { useEffect, useRef, useState } from "react";
 import Typography from "@mui/material/Typography";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import PropTypes from "prop-types";
 import { TextFieldUncontrolled } from "./TextFields";
-import clsx from "clsx";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     text: {
         maxWidth: 300,
         [theme.breakpoints.down("lg")]: {
@@ -41,7 +40,7 @@ function ClickableTextField(props) {
     const [value, setValue] = useState("");
     const firstValue = useRef(props.value);
 
-    const classes = useStyles();
+    const { classes, cx } = useStyles();
 
     function onChange(e) {
         props.onChange(e.target.value);
@@ -85,7 +84,7 @@ function ClickableTextField(props) {
         <Typography
             noWrap
             aria-label={label}
-            className={clsx(
+            className={cx(
                 classes.hoverHighlight,
                 classes.enabled,
                 classes.text
@@ -100,7 +99,7 @@ function ClickableTextField(props) {
             noWrap
             aria-label={label}
             onClick={toggleEditMode}
-            className={clsx(
+            className={cx(
                 classes.hoverHighlight,
                 classes.label,
                 classes.enabled,
@@ -120,7 +119,7 @@ function ClickableTextField(props) {
                 inputProps={{
                     "aria-label": label,
                 }}
-                className={clsx(classes.label, classes.text)}
+                className={cx(classes.label, classes.text)}
                 tel={props.tel}
                 onPressEnter={(ev) => {
                     onFinishedEntry(ev);

--- a/src/components/ContactForm.js
+++ b/src/components/ContactForm.js
@@ -1,8 +1,8 @@
 import React from "react";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import { TextFieldUncontrolled } from "./TextFields";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     root: {
         display: "flex",
         flexDirection: "column",
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
 const fields = { name: "Name", telephoneNumber: "Telephone" };
 
 export const ContactForm = ({ values, onChange, italicTel }) => {
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <form className={classes.root} noValidate autoComplete="off">

--- a/src/components/ContextMenus/CommentContextMenu.js
+++ b/src/components/ContextMenus/CommentContextMenu.js
@@ -17,7 +17,7 @@ const initialState = {
 };
 
 export default function CommentContextMenu(props) {
-    const classes = deleteButtonStyles();
+    const { classes } = deleteButtonStyles();
     const [state, setState] = React.useState(initialState);
     const [comment, setComment] = useState(props.comment);
     const [deleteConfirmation, setDeleteConfirmation] = useState(false);

--- a/src/components/ContextMenus/TaskContextMenu.js
+++ b/src/components/ContextMenus/TaskContextMenu.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Menu from "@mui/material/Menu";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import MenuItem from "@mui/material/MenuItem";
 import { useDispatch, useSelector } from "react-redux";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
@@ -37,15 +37,14 @@ function TaskContextMenu(props) {
     const [isPosting, setIsPosting] = React.useState(false);
     const roleView = useSelector(getRoleView);
     const whoami = useSelector(getWhoami);
-    const deleteButtonClasses = deleteButtonStyles();
     const taskAssignees = useSelector(taskAssigneesSelector).items;
     const tenantId = useSelector(tenantIdSelector);
-    const useStyles = makeStyles({
+    const useStyles = makeStyles()({
         taskContextButton: {
             color: props.iconColor || "primary",
         },
     });
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     const actualRole = ["ALL", userRoles.coordinator].includes(roleView)
         ? userRoles.coordinator
@@ -296,16 +295,6 @@ function TaskContextMenu(props) {
                 <MenuItem disabled={task === null} onClick={copyToClipboard}>
                     Copy to clipboard
                 </MenuItem>
-                <MenuItem
-                    className={
-                        props.disableDeleted
-                            ? deleteButtonClasses.deleteButtonDisabled
-                            : deleteButtonClasses.deleteButton
-                    }
-                    onClick={onDelete}
-                >
-                    Delete
-                </MenuItem>
             </Menu>
         </>
     );
@@ -314,7 +303,6 @@ function TaskContextMenu(props) {
 TaskContextMenu.propTypes = {
     task: PropTypes.object,
     iconColor: PropTypes.string,
-    disableDeleted: PropTypes.bool,
     disableRelay: PropTypes.bool,
     assignedRiders: PropTypes.arrayOf(PropTypes.object),
 };

--- a/src/components/ContextMenus/UserContextMenu.js
+++ b/src/components/ContextMenus/UserContextMenu.js
@@ -5,10 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import IconButton from "@mui/material/IconButton";
 import { createPostingSelector } from "../../redux/LoadingSelectors";
-import {
-    deleteUserRequest,
-    restoreUserRequest,
-} from "../../redux/users/UsersActions";
+import { deleteUserRequest } from "../../redux/users/UsersActions";
 import { deleteButtonStyles } from "./contextMenuCSS";
 import { getWhoami } from "../../redux/Selectors";
 
@@ -18,7 +15,7 @@ const initialState = {
 };
 
 export default function UserContextMenu(props) {
-    const classes = deleteButtonStyles();
+    const { classes } = deleteButtonStyles();
     const whoami = useSelector(getWhoami);
     const [state, setState] = React.useState(initialState);
     const postingSelector = createPostingSelector([
@@ -45,37 +42,40 @@ export default function UserContextMenu(props) {
         setState(initialState);
     };
 
-    return <>
-        <IconButton
-            aria-label="more"
-            aria-controls="long-menu"
-            aria-haspopup="true"
-            onClick={handleClick}
-            disabled={isPosting}
-            size="large">
-            <MoreVertIcon />
-        </IconButton>
-        <Menu
-            keepMounted
-            open={state.mouseY !== null}
-            onClose={handleClose}
-            anchorReference="anchorPosition"
-            anchorPosition={
-                state.mouseY !== null && state.mouseX !== null
-                    ? { top: state.mouseY, left: state.mouseX }
-                    : undefined
-            }
-        >
-            <MenuItem
-                className={
-                    whoami.roles.includes("ADMIN")
-                        ? classes.deleteButton
-                        : classes.deleteButtonDisabled
-                }
-                onClick={onDelete}
+    return (
+        <>
+            <IconButton
+                aria-label="more"
+                aria-controls="long-menu"
+                aria-haspopup="true"
+                onClick={handleClick}
+                disabled={isPosting}
+                size="large"
             >
-                Delete
-            </MenuItem>
-        </Menu>
-    </>;
+                <MoreVertIcon />
+            </IconButton>
+            <Menu
+                keepMounted
+                open={state.mouseY !== null}
+                onClose={handleClose}
+                anchorReference="anchorPosition"
+                anchorPosition={
+                    state.mouseY !== null && state.mouseX !== null
+                        ? { top: state.mouseY, left: state.mouseX }
+                        : undefined
+                }
+            >
+                <MenuItem
+                    className={
+                        whoami.roles.includes("ADMIN")
+                            ? classes.deleteButton
+                            : classes.deleteButtonDisabled
+                    }
+                    onClick={onDelete}
+                >
+                    Delete
+                </MenuItem>
+            </Menu>
+        </>
+    );
 }

--- a/src/components/ContextMenus/VehicleContextMenu.js
+++ b/src/components/ContextMenus/VehicleContextMenu.js
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from "react-redux";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import IconButton from "@mui/material/IconButton";
 import { createPostingSelector } from "../../redux/LoadingSelectors";
-import { deleteButtonStyles, contextDots } from "./contextMenuCSS";
+import { deleteButtonStyles } from "./contextMenuCSS";
 import { getWhoami } from "../../redux/Selectors";
 
 const initialState = {
@@ -15,7 +15,7 @@ const initialState = {
 };
 
 export default function VehicleContextMenu(props) {
-    const classes = deleteButtonStyles();
+    const { classes } = deleteButtonStyles();
     const [state, setState] = React.useState(initialState);
     const postingSelector = createPostingSelector([
         "DELETE_VEHICLE",
@@ -42,37 +42,40 @@ export default function VehicleContextMenu(props) {
         setState(initialState);
     };
 
-    return <>
-        <IconButton
-            aria-label="more"
-            aria-controls="long-menu"
-            aria-haspopup="true"
-            onClick={handleClick}
-            disabled={isPosting}
-            size="large">
-            <MoreVertIcon />
-        </IconButton>
-        <Menu
-            keepMounted
-            open={state.mouseY !== null}
-            onClose={handleClose}
-            anchorReference="anchorPosition"
-            anchorPosition={
-                state.mouseY !== null && state.mouseX !== null
-                    ? { top: state.mouseY, left: state.mouseX }
-                    : undefined
-            }
-        >
-            <MenuItem
-                className={
-                    whoami.roles.includes("ADMIN")
-                        ? classes.deleteButton
-                        : classes.deleteButtonDisabled
-                }
-                onClick={onDelete}
+    return (
+        <>
+            <IconButton
+                aria-label="more"
+                aria-controls="long-menu"
+                aria-haspopup="true"
+                onClick={handleClick}
+                disabled={isPosting}
+                size="large"
             >
-                Delete
-            </MenuItem>
-        </Menu>
-    </>;
+                <MoreVertIcon />
+            </IconButton>
+            <Menu
+                keepMounted
+                open={state.mouseY !== null}
+                onClose={handleClose}
+                anchorReference="anchorPosition"
+                anchorPosition={
+                    state.mouseY !== null && state.mouseX !== null
+                        ? { top: state.mouseY, left: state.mouseX }
+                        : undefined
+                }
+            >
+                <MenuItem
+                    className={
+                        whoami.roles.includes("ADMIN")
+                            ? classes.deleteButton
+                            : classes.deleteButtonDisabled
+                    }
+                    onClick={onDelete}
+                >
+                    Delete
+                </MenuItem>
+            </Menu>
+        </>
+    );
 }

--- a/src/components/ContextMenus/contextMenuCSS.js
+++ b/src/components/ContextMenus/contextMenuCSS.js
@@ -1,6 +1,6 @@
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 
-export const deleteButtonStyles = makeStyles((theme) => ({
+export const deleteButtonStyles = makeStyles()((theme) => ({
     deleteButton: {
         display: "inherit",
         color: "rgb(235, 86, 75)",

--- a/src/components/CustomizedDialogs.js
+++ b/src/components/CustomizedDialogs.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types'
 
-import withStyles from '@mui/styles/withStyles';
-import makeStyles from '@mui/styles/makeStyles';
+import { withStyles } from 'tss-react/mui';
+import { makeStyles } from 'tss-react/mui';
 import Dialog from '@mui/material/Dialog';
 import MuiDialogTitle from '@mui/material/DialogTitle';
 import MuiDialogContent from '@mui/material/DialogContent';
@@ -24,7 +24,7 @@ const styles = (theme) => ({
   },
 });
 
-const DialogTitle = withStyles(styles)((props) => {
+const DialogTitle = withStyles((props) => {
   const { children, classes, onClose, ...other } = props;
   return (
     <MuiDialogTitle disableTypography className={classes.root} {...other}>
@@ -40,23 +40,23 @@ const DialogTitle = withStyles(styles)((props) => {
       ) : null}
     </MuiDialogTitle>
   );
-});
+}, styles);
 
-const DialogContent = withStyles((theme) => ({
+const DialogContent = withStyles(MuiDialogContent, (theme) => ({
   root: {
     padding: theme.spacing(2),
   },
-}))(MuiDialogContent);
+}));
 
-const DialogActions = withStyles((theme) => ({
+const DialogActions = withStyles(MuiDialogActions, (theme) => ({
   root: {
     display: "inline-block",
     margin: 0,
     padding: theme.spacing(1),
   },
-}))(MuiDialogActions);
+}));
 
-const CustomizedDialogsStyles = makeStyles((theme) => ({
+const CustomizedDialogsStyles = makeStyles()((theme) => ({
   dialogPaper: {
     minHeight: '60vh',
     maxHeight: '60vh',
@@ -64,7 +64,7 @@ const CustomizedDialogsStyles = makeStyles((theme) => ({
 }));
 
 export const CustomizedDialogs = ({ open, onClose, children })  => {
-  const classes = CustomizedDialogsStyles()
+  const { classes } = CustomizedDialogsStyles()
   return (
     <Dialog 
       classes={{ paper: classes.dialogPaper }}

--- a/src/components/IncreaseDecreaseCounter.js
+++ b/src/components/IncreaseDecreaseCounter.js
@@ -6,11 +6,11 @@ import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 import PropTypes from "prop-types";
 import ClearIcon from "@mui/icons-material/Clear";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 
 function IncreaseDecreaseCounter(props) {
     const [state, setState] = useState(props.value);
-    const useStyles = makeStyles((theme) => ({
+    const useStyles = makeStyles()((theme) => ({
         button: {
             width: theme.spacing(4),
             height: theme.spacing(4),
@@ -20,7 +20,7 @@ function IncreaseDecreaseCounter(props) {
             height: theme.spacing(4),
         },
     }));
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <Grid

--- a/src/components/SnackNotificationButtons.js
+++ b/src/components/SnackNotificationButtons.js
@@ -2,10 +2,9 @@ import { Button } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
-import { showHide, DismissButton } from "../styles/common";
+import { DismissButton } from "../styles/common";
 
 function SnackNotificationButtons(props) {
-    const { show, hide } = showHide();
     const [showUndo, setShowUndo] = useState(!!props.restoreCallback);
     const { restoreCallback, viewLink, snackKey, closeSnackbar } = props;
     useEffect(() => {
@@ -13,26 +12,28 @@ function SnackNotificationButtons(props) {
     }, []);
     return (
         <React.Fragment>
-            <Button
-                className={showUndo ? show : hide}
-                color="secondary"
-                size="small"
-                onClick={() => {
-                    props.closeSnackbar(snackKey);
-                    restoreCallback();
-                }}
-            >
-                UNDO
-            </Button>
-            <Button
-                className={viewLink ? show : hide}
-                color="secondary"
-                size="small"
-                component={Link}
-                to={viewLink || "/"}
-            >
-                VIEW
-            </Button>
+            {showUndo && (
+                <Button
+                    color="secondary"
+                    size="small"
+                    onClick={() => {
+                        props.closeSnackbar(snackKey);
+                        restoreCallback();
+                    }}
+                >
+                    UNDO
+                </Button>
+            )}
+            {viewLink && (
+                <Button
+                    color="secondary"
+                    size="small"
+                    component={Link}
+                    to={viewLink || "/"}
+                >
+                    VIEW
+                </Button>
+            )}
             {closeSnackbar ? (
                 <DismissButton onClick={() => closeSnackbar(snackKey)} />
             ) : (

--- a/src/components/TaskFilterTextfield.js
+++ b/src/components/TaskFilterTextfield.js
@@ -6,12 +6,12 @@ import { InputAdornment, TextField } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import React, { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import PropTypes from "prop-types";
 import { dashboardFilterTermSelector } from "../redux/Selectors";
 import { styled } from "@mui/material/styles";
 
-const useStyles = makeStyles((theme) => {
+const useStyles = makeStyles()((theme) => {
     return {
         root: {
             [theme.breakpoints.down("md")]: {
@@ -41,7 +41,7 @@ function TaskFilterTextField({ sx }) {
     const dispatch = useDispatch();
     const currentFilter = useSelector(dashboardFilterTermSelector);
     const [value, setValue] = useState("");
-    const classes = useStyles();
+    const { classes } = useStyles();
     const firstMount = useRef(true);
 
     function onChangeFilterText(e) {

--- a/src/components/UserAvatar.js
+++ b/src/components/UserAvatar.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import Avatar from "@mui/material/Avatar";
 import seedrandom from "seedrandom";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import PropTypes from "prop-types";
 import { generateS3Link } from "../amplifyUtilities";
 
@@ -46,7 +46,7 @@ const UserAvatar = React.memo((props) => {
 
     useEffect(() => getThumbnail(), [props.thumbnailKey, getThumbnail]);
 
-    const useStyles = makeStyles((theme) => ({
+    const useStyles = makeStyles()((theme) => ({
         card: {
             color: theme.palette.getContrastText(avatarFallbackColor),
             backgroundColor: avatarFallbackColor,
@@ -56,7 +56,7 @@ const UserAvatar = React.memo((props) => {
         },
     }));
 
-    const classes = useStyles();
+    const { classes } = useStyles();
     return (
         <Avatar
             onClick={props.onClick}

--- a/src/components/UserCard.js
+++ b/src/components/UserCard.js
@@ -5,7 +5,7 @@ import UserAvatar from "./UserAvatar";
 import IconButton from "@mui/material/IconButton";
 import ClearIcon from "@mui/icons-material/Clear";
 import { Box, Stack, styled } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import { ThemedLink } from "../styles/common";
 
 const UserBox = styled(Box)({
@@ -15,7 +15,7 @@ const UserBox = styled(Box)({
     maxWidth: 500,
 });
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     button: {
         width: theme.spacing(4),
         height: theme.spacing(4),
@@ -31,7 +31,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function UserCard(props) {
-    const classes = useStyles();
+    const { classes } = useStyles();
     const deleteButton = props.onDelete ? (
         <IconButton
             aria-label="delete"

--- a/src/components/UsersSelect.js
+++ b/src/components/UsersSelect.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import deburr from "lodash/deburr";
 import Downshift from "downshift";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import TextField from "@mui/material/TextField";
 import Paper from "@mui/material/Paper";
 import MenuItem from "@mui/material/MenuItem";
@@ -92,7 +92,7 @@ function getSuggestions(suggestions, value, { showEmpty = false } = {}) {
 }
 
 function UsersSelect(props) {
-    let classes = makeStyles((theme) => ({
+    let classes = makeStyles()((theme) => ({
         root: {
             flexGrow: 1,
             height: 250,

--- a/src/components/deliverableIcons/BugIcon.js
+++ b/src/components/deliverableIcons/BugIcon.js
@@ -1,17 +1,17 @@
 import React from "react";
 import { Avatar } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import BugReportIcon from "@mui/icons-material/BugReport";
 import { red } from "@mui/material/colors";
 import PropTypes from "prop-types";
 
-const useStyles = makeStyles((theme) => ({
-    root: (size) => ({
+const useStyles = makeStyles()((theme, { size }) => ({
+    root: {
         color: theme.palette.getContrastText(red[500]),
         backgroundColor: red[500],
         width: theme.spacing(size),
         height: theme.spacing(size),
-    }),
+    },
     icon: {
         width: "100%",
         height: "100%",
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function BugIcon({ size }) {
-    const classes = useStyles(size);
+    const { classes } = useStyles({ size });
     return (
         <Avatar
             aria-label="Bug icon"

--- a/src/components/deliverableIcons/ChildIcon.js
+++ b/src/components/deliverableIcons/ChildIcon.js
@@ -1,17 +1,17 @@
 import React from "react";
 import { Avatar } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import ChildCareIcon from "@mui/icons-material/ChildCare";
 import { pink } from "@mui/material/colors";
 import PropTypes from "prop-types";
 
-const useStyles = makeStyles((theme) => ({
-    root: (size) => ({
+const useStyles = makeStyles()((theme, { size }) => ({
+    root: {
         color: theme.palette.getContrastText(pink[400]),
         backgroundColor: pink[400],
         width: theme.spacing(size),
         height: theme.spacing(size),
-    }),
+    },
     icon: {
         width: "100%",
         height: "100%",
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function ChildIcon({ size }) {
-    const classes = useStyles(size);
+    const { classes } = useStyles({ size });
     return (
         <Avatar
             aria-label="Child icon"

--- a/src/components/deliverableIcons/DocumentIcon.js
+++ b/src/components/deliverableIcons/DocumentIcon.js
@@ -1,17 +1,17 @@
 import React from "react";
 import { Avatar } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import DescriptionIcon from "@mui/icons-material/Description";
 import { deepPurple } from "@mui/material/colors";
 import PropTypes from "prop-types";
 
-const useStyles = makeStyles((theme) => ({
-    root: (size) => ({
+const useStyles = makeStyles()((theme, { size }) => ({
+    root: {
         color: theme.palette.getContrastText(deepPurple[500]),
         backgroundColor: deepPurple[500],
         width: theme.spacing(size),
         height: theme.spacing(size),
-    }),
+    },
     icon: {
         width: "100%",
         height: "100%",
@@ -19,7 +19,9 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function DocumentIcon({ size }) {
-    const classes = useStyles(size);
+    const { classes } = useStyles({
+        size,
+    });
     return (
         <Avatar
             aria-label="Document icon"

--- a/src/components/deliverableIcons/EquipmentIcon.js
+++ b/src/components/deliverableIcons/EquipmentIcon.js
@@ -1,17 +1,17 @@
 import React from "react";
 import { Avatar } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import BuildIcon from "@mui/icons-material/Build";
 import { blue } from "@mui/material/colors";
 import PropTypes from "prop-types";
 
-const useStyles = makeStyles((theme) => ({
-    root: (size) => ({
+const useStyles = makeStyles()((theme, { size }) => ({
+    root: {
         color: theme.palette.getContrastText(blue[500]),
         backgroundColor: blue[500],
         width: theme.spacing(size),
         height: theme.spacing(size),
-    }),
+    },
     icon: {
         width: "100%",
         height: "100%",
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function EquipmentIcon({ size }) {
-    const classes = useStyles(size);
+    const { classes } = useStyles({ size });
     return (
         <Avatar
             aria-label="Equipment icon"

--- a/src/components/deliverableIcons/OtherIcon.js
+++ b/src/components/deliverableIcons/OtherIcon.js
@@ -1,25 +1,27 @@
 import React from "react";
 import { Avatar } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import AcUnitIcon from "@mui/icons-material/AcUnit";
 import { lightGreen } from "@mui/material/colors";
 import PropTypes from "prop-types";
 
-const useStyles = makeStyles((theme) => ({
-    root: (size) => ({
-        color: "white",
-        backgroundColor: lightGreen[500],
-        width: theme.spacing(size),
-        height: theme.spacing(size),
-    }),
-    icon: {
-        width: "100%",
-        height: "100%",
-    },
-}));
+const useStyles = makeStyles()((theme, { size }) => {
+    return {
+        root: {
+            color: "white",
+            backgroundColor: lightGreen[500],
+            width: theme.spacing(size),
+            height: theme.spacing(size),
+        },
+        icon: {
+            width: "100%",
+            height: "100%",
+        },
+    };
+});
 
 function OtherIcon({ size }) {
-    const classes = useStyles(size);
+    const { classes } = useStyles({ size });
     return (
         <Avatar
             aria-label="Other icon"

--- a/src/navigation/Components/ExpandableTaskFilter.js
+++ b/src/navigation/Components/ExpandableTaskFilter.js
@@ -1,18 +1,22 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 import TaskFilterTextField from "../../components/TaskFilterTextfield";
-import {showHide} from "../../styles/common";
+import { showHide } from "../../styles/common";
 import SearchIcon from "@mui/icons-material/Search";
 import IconButton from "@mui/material/IconButton";
 
-function ExpandableTaskFilter(props) {
+function ExpandableTaskFilter() {
     const [open, setOpen] = useState(false);
-    const {show, hide} = showHide();
+    const { show, hide } = showHide().classes;
     return (
         <div>
-            <IconButton className={open ? hide : show} onClick={() => setOpen(true)} size="large">
-                <SearchIcon/>
+            <IconButton
+                className={open ? hide : show}
+                onClick={() => setOpen(true)}
+                size="large"
+            >
+                <SearchIcon />
             </IconButton>
-            <TaskFilterTextField className={open ? show : hide}/>
+            <TaskFilterTextField className={open ? show : hide} />
         </div>
     );
 }

--- a/src/navigation/MainWindow.js
+++ b/src/navigation/MainWindow.js
@@ -11,7 +11,7 @@ import LocationDetailRoute from "../scenes/LocationDetail/LocationDetailRoute";
 import StatisticsDashboard from "../scenes/Statistics/StatisticsDashboard";
 import { useDispatch, useSelector } from "react-redux";
 import { setMenuIndex } from "../redux/Actions";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import AdminAddUser from "../scenes/AdminControl/Components/AdminAddUser";
 import AdminAddVehicle from "../scenes/AdminControl/Components/AdminAddVehicle";
 import AdminAddLocation from "../scenes/AdminControl/Components/AdminAddLocation";
@@ -27,7 +27,7 @@ import UserDetailRoute from "../scenes/UserDetail/UserDetailRoute";
 function MainWindowContainer(props) {
     const guidedSetupOpen = useSelector(guidedSetupOpenSelector);
     const navIndex = useSelector(menuIndexSelector);
-    const styles = makeStyles((theme) => ({
+    const styles = makeStyles()((theme) => ({
         root: {
             marginRight:
                 guidedSetupOpen && navIndex === "dashboard" ? 0 : "auto",
@@ -41,7 +41,7 @@ function MainWindowContainer(props) {
             },
         },
     }));
-    const classes = styles();
+    const { classes } = styles();
     return <Box className={classes.root}>{props.children}</Box>;
 }
 

--- a/src/navigation/MainWindow.js
+++ b/src/navigation/MainWindow.js
@@ -11,7 +11,7 @@ import LocationDetailRoute from "../scenes/LocationDetail/LocationDetailRoute";
 import StatisticsDashboard from "../scenes/Statistics/StatisticsDashboard";
 import { useDispatch, useSelector } from "react-redux";
 import { setMenuIndex } from "../redux/Actions";
-import { makeStyles } from 'tss-react/mui';
+import { makeStyles } from "tss-react/mui";
 import AdminAddUser from "../scenes/AdminControl/Components/AdminAddUser";
 import AdminAddVehicle from "../scenes/AdminControl/Components/AdminAddVehicle";
 import AdminAddLocation from "../scenes/AdminControl/Components/AdminAddLocation";
@@ -24,24 +24,24 @@ import { Box } from "@mui/material";
 import Reports from "../scenes/Reports/Reports";
 import UserDetailRoute from "../scenes/UserDetail/UserDetailRoute";
 
+const useStyles = makeStyles()((theme, { navIndex, guidedSetupOpen }) => ({
+    root: {
+        marginRight: guidedSetupOpen && navIndex === "dashboard" ? 0 : "auto",
+        marginLeft: navIndex === "dashboard" ? 0 : 200,
+        paddingTop: 10,
+        paddingBottom: 10,
+        [theme.breakpoints.down("md")]: {
+            paddingTop: 5,
+            marginLeft: 0,
+            marginRight: 0,
+        },
+    },
+}));
+
 function MainWindowContainer(props) {
     const guidedSetupOpen = useSelector(guidedSetupOpenSelector);
     const navIndex = useSelector(menuIndexSelector);
-    const styles = makeStyles()((theme) => ({
-        root: {
-            marginRight:
-                guidedSetupOpen && navIndex === "dashboard" ? 0 : "auto",
-            marginLeft: navIndex === "dashboard" ? 0 : 200,
-            paddingTop: 10,
-            paddingBottom: 10,
-            [theme.breakpoints.down("md")]: {
-                paddingTop: 5,
-                marginLeft: 0,
-                marginRight: 0,
-            },
-        },
-    }));
-    const { classes } = styles();
+    const { classes } = useStyles({ guidedSetupOpen, navIndex });
     return <Box className={classes.root}>{props.children}</Box>;
 }
 

--- a/src/navigation/MenuMainContainer.js
+++ b/src/navigation/MenuMainContainer.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import "../index.css";
 import { useTheme } from "@mui/material/styles";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import AppBar from "@mui/material/AppBar";
 import IconButton from "@mui/material/IconButton";
 import MainWindow from "./MainWindow";
@@ -20,7 +20,7 @@ import {
     menuIndexSelector,
 } from "../redux/Selectors";
 
-const useStyles = makeStyles((theme) => {
+const useStyles = makeStyles()((theme) => {
     return {
         appBarComponents: {
             margin: "auto",
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme) => {
 });
 
 export function MenuMainContainer() {
-    const classes = useStyles();
+    const { classes } = useStyles();
     const [searchMode, setSearchMode] = useState(false);
     const menuIndex = useSelector(menuIndexSelector);
     const currentFilter = useSelector(dashboardFilterTermSelector);

--- a/src/navigation/MobileNavigationDrawer.js
+++ b/src/navigation/MobileNavigationDrawer.js
@@ -2,12 +2,12 @@ import React, { useState } from "react";
 import NavDrawerItems from "./NavDrawerItems";
 import IconButton from "@mui/material/IconButton";
 import MenuIcon from "@mui/icons-material/Menu";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import { Stack, SwipeableDrawer } from "@mui/material";
 import { useCordovaBackButton } from "../hooks/useCordovaBackButton";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     list: {
         width: 250,
     },
@@ -15,7 +15,7 @@ const useStyles = makeStyles({
 
 export default function MobileNavigationDrawer() {
     const [open, setOpen] = useState(false);
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     useCordovaBackButton(() => {
         setOpen(false);

--- a/src/scenes/AdminControl/Components/AdminAddDeliverableType.js
+++ b/src/scenes/AdminControl/Components/AdminAddDeliverableType.js
@@ -1,5 +1,5 @@
 import { Button, Grid, Skeleton, TextField, Typography } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import React, { useEffect, useState } from "react";
 import { PaddedPaper } from "../../../styles/common";
 import * as models from "../../../models/index";
@@ -21,7 +21,7 @@ const initialDeliverableTypeState = {
     tags: [],
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     root: {
         width: "100%",
         maxWidth: 460,
@@ -43,7 +43,7 @@ function AdminAddDeliverableType() {
     const [isPosting, setIsPosting] = useState(false);
     const [inputVerified, setInputVerified] = useState(false);
     const dispatch = useDispatch();
-    const classes = useStyles();
+    const { classes } = useStyles();
     const whoami = useSelector(getWhoami);
 
     async function addDeliverableTypeToStore() {

--- a/src/scenes/AdminControl/Components/AdminAddLocation.js
+++ b/src/scenes/AdminControl/Components/AdminAddLocation.js
@@ -7,7 +7,7 @@ import {
     TextField,
     Typography,
 } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { TextFieldUncontrolled } from "../../../components/TextFields";
@@ -44,7 +44,7 @@ const initialLocationState = {
     googleMapsPlaceId: null,
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     root: {
         width: "100%",
         maxWidth: 460,
@@ -82,7 +82,7 @@ function AdminAddLocation() {
     const whoamiFetching = useSelector(loadingSelector);
     const [inputVerified, setInputVerified] = useState(false);
     const dispatch = useDispatch();
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     function verifyInput() {
         setInputVerified(!!state.name);

--- a/src/scenes/AdminControl/Components/AdminAddRiderResponsibility.js
+++ b/src/scenes/AdminControl/Components/AdminAddRiderResponsibility.js
@@ -1,5 +1,5 @@
 import { Button, Skeleton, Stack, Typography } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import React, { useEffect, useState } from "react";
 import { TextFieldUncontrolled } from "../../../components/TextFields";
 import { PaddedPaper } from "../../../styles/common";
@@ -16,7 +16,7 @@ const initialRiderResponsibilityState = {
     label: "",
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     root: {
         width: "100%",
         maxWidth: 460,
@@ -38,7 +38,7 @@ function AdminAddRiderResponsibility() {
     const [isPosting, setIsPosting] = useState(false);
     const [inputVerified, setInputVerified] = useState(false);
     const dispatch = useDispatch();
-    const classes = useStyles();
+    const { classes } = useStyles();
     const whoami = useSelector(getWhoami);
 
     async function addRiderResponsibilityToStore() {

--- a/src/scenes/AdminControl/Components/AdminAddUser.js
+++ b/src/scenes/AdminControl/Components/AdminAddUser.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Skeleton } from "@mui/material";
 import { Button, TextField, Typography, Stack } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import { TextFieldUncontrolled } from "../../../components/TextFields";
 import { PaddedPaper } from "../../../styles/common";
 import { useDispatch, useSelector } from "react-redux";
@@ -18,7 +18,7 @@ import * as mutations from "../../../graphql/mutations";
 import { API, graphqlOperation } from "aws-amplify";
 import UserRoleSelect from "../../../components/UserRoleSelect";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     root: {
         maxWidth: 460,
     },
@@ -47,7 +47,7 @@ function AdminAddUser() {
     const [inputVerified, setInputVerified] = useState(false);
     const [isPosting, setIsPosting] = useState(false);
     const dispatch = useDispatch();
-    const classes = useStyles();
+    const { classes } = useStyles();
     const [rolesState, setRolesState] = useState([]);
 
     function onClickToggle(key) {

--- a/src/scenes/AdminControl/Components/AdminAddVehicle.js
+++ b/src/scenes/AdminControl/Components/AdminAddVehicle.js
@@ -1,5 +1,5 @@
 import { Button, Grid, Skeleton, TextField, Typography } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import DatePicker from "@mui/lab/DatePicker";
 import React, { useEffect, useState } from "react";
 import { PaddedPaper } from "../../../styles/common";
@@ -23,7 +23,7 @@ const initialVehicleState = {
     dateOfRegistration: null,
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     root: {
         width: "100%",
         maxWidth: 460,
@@ -44,7 +44,7 @@ function AdminAddVehicle() {
     const [isPosting, setIsPosting] = useState(false);
     const [inputVerified, setInputVerified] = useState(false);
     const dispatch = useDispatch();
-    const classes = useStyles();
+    const { classes } = useStyles();
     const whoami = useSelector(getWhoami);
 
     async function addVehicleToStore() {

--- a/src/scenes/AdminControl/Components/DeliverableIconPicker.js
+++ b/src/scenes/AdminControl/Components/DeliverableIconPicker.js
@@ -1,18 +1,18 @@
 import { Grid, IconButton } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import React from "react";
 import { deliverableIcons } from "../../../apiConsts";
 import { getDeliverableIconByEnum } from "../../../utilities";
 import PropTypes from "prop-types";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     selection: {
         background: theme.palette.background.default,
         borderRadius: 6,
     },
 }));
 function DeliverableIconPicker(props) {
-    const classes = useStyles();
+    const { classes } = useStyles();
     return (
         <Grid container>
             {Object.values(deliverableIcons).map((icon) => {

--- a/src/scenes/Comments/components/Comment.js
+++ b/src/scenes/Comments/components/Comment.js
@@ -77,7 +77,7 @@ function Comment(props) {
         ...props,
         editMode: editMode,
     });
-    const classes = commentStyles();
+    const { classes } = commentStyles();
 
     useEffect(() => {
         setState(props.comment);

--- a/src/scenes/Comments/components/CommentAuthor.js
+++ b/src/scenes/Comments/components/CommentAuthor.js
@@ -2,13 +2,13 @@ import React from "react";
 import UserAvatar from "../../../components/UserAvatar";
 import { Link as RouterLink } from "react-router-dom";
 import { encodeUUID } from "../../../utilities";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import PropTypes from "prop-types";
 import { Typography } from "@mui/material";
 import { Grid } from "@mui/material";
 import { ThemedLink } from "../../../styles/common";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     link: {
         textDecoration: "none",
         "&:hover": {
@@ -19,7 +19,7 @@ const useStyles = makeStyles({
 });
 
 const CommentAuthor = React.memo((props) => {
-    const classes = useStyles();
+    const { classes } = useStyles();
     if (!props.userId) {
         return null;
     }

--- a/src/scenes/Comments/components/CommentCard.js
+++ b/src/scenes/Comments/components/CommentCard.js
@@ -19,8 +19,8 @@ import { getWhoami } from "../../../redux/Selectors";
 import { commentVisibility } from "../../../apiConsts";
 
 const CommentCard = React.memo((props) => {
-    const { show, hide } = showHide();
-    const classes = commentStyles();
+    const { show, hide } = showHide().classes;
+    const { classes } = commentStyles();
     const timeCreatedString = moment(props.timeCreated).calendar();
     const whoami = useSelector(getWhoami);
     const Card =

--- a/src/scenes/Comments/components/CommentsMain.js
+++ b/src/scenes/Comments/components/CommentsMain.js
@@ -2,13 +2,13 @@ import Grid from "@mui/material/Grid";
 import React from "react";
 import NewCommentCard from "./NewCommentCard";
 import { useSelector } from "react-redux";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from 'tss-react/mui';
 import PropTypes from "prop-types";
 import { getWhoami } from "../../../redux/Selectors";
 import Comment from "./Comment";
 
 function CommentsMain(props) {
-    const useStyles = makeStyles(() => ({
+    const useStyles = makeStyles()(() => ({
         root: {
             flexGrow: 1,
             width: "100%",
@@ -24,7 +24,7 @@ function CommentsMain(props) {
             height: 5,
         },
     }));
-    const classes = useStyles();
+    const { classes } = useStyles();
     const whoami = useSelector(getWhoami);
 
     return (

--- a/src/scenes/Comments/components/NewCommentCard.js
+++ b/src/scenes/Comments/components/NewCommentCard.js
@@ -26,7 +26,7 @@ function NewCommentCard(props) {
     const tenantId = useSelector(tenantIdSelector);
     const dispatch = useDispatch();
 
-    const classes = commentStyles();
+    const { classes } = commentStyles();
 
     async function addComment() {
         setIsPosting(true);

--- a/src/scenes/Comments/styles/CommentCards.js
+++ b/src/scenes/Comments/styles/CommentCards.js
@@ -1,6 +1,6 @@
 import Paper from "@mui/material/Paper";
-import { styled } from '@mui/material/styles';
-import makeStyles from '@mui/styles/makeStyles';
+import { styled } from "@mui/material/styles";
+import { makeStyles } from "tss-react/mui";
 
 export const CommentCardStyled = styled(Paper)({
     position: "relative",
@@ -28,7 +28,7 @@ export const PrivateCommentCardStyled = styled(Paper)({
     },
 });
 
-export const commentStyles = makeStyles((theme) => ({
+export const commentStyles = makeStyles()((theme) => ({
     newComment: {
         width: "100%",
         minWidth: 350,

--- a/src/scenes/CoordinatorSetup/CoordinatorSetup.js
+++ b/src/scenes/CoordinatorSetup/CoordinatorSetup.js
@@ -1,5 +1,5 @@
 import React from "react";
-import makeStyles from '@mui/styles/makeStyles';
+import { makeStyles } from 'tss-react/mui';
 import {Grid} from '@mui/material';
 import Divider from '@mui/material/Divider';
 import Paper from '@mui/material/Paper';
@@ -12,7 +12,7 @@ import { EnhancedTable } from './components/EnhancedTable'
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 
-const setupStyles = makeStyles((theme) => ({
+const setupStyles = makeStyles()((theme) => ({
     container: {
         display: "flex",
         flexDirection: "column",
@@ -34,7 +34,7 @@ const Item = styled(Paper)(({ theme }) => ({
   }));
 
 export const CoordinatorSetup = ({ show, onClose }) => {
-    const classes = setupStyles();
+    const { classes } = setupStyles();
     
     return (
         <div className={classes.container}>

--- a/src/scenes/CoordinatorSetup/components/RiderJobActivity.js
+++ b/src/scenes/CoordinatorSetup/components/RiderJobActivity.js
@@ -1,9 +1,9 @@
 import React from "react";
 import Typography from '@mui/material/Typography';
-import makeStyles from '@mui/styles/makeStyles';
+import { makeStyles } from 'tss-react/mui';
 import {Grid} from '@mui/material';
 
-const riderJobActivityStyles = makeStyles((theme) => ({
+const riderJobActivityStyles = makeStyles()((theme) => ({
     wrapper: {
         marginBottom: "100px",
     },
@@ -21,7 +21,7 @@ const riderJobActivityStyles = makeStyles((theme) => ({
   }));
 
 export const RiderJobActivity = () => {
-    const classes = riderJobActivityStyles();
+    const { classes } = riderJobActivityStyles();
 
     return (
         <div className={classes.wrapper}>

--- a/src/scenes/Dashboard/components/ActiveRidersChips.tsx
+++ b/src/scenes/Dashboard/components/ActiveRidersChips.tsx
@@ -23,44 +23,38 @@ import UserChip from "../../../components/UserChip";
 import { setDashboardFilteredUser } from "../../../redux/Actions";
 import moment from "moment";
 import * as models from "../../../models";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import convertModelsToObject, {
     PersistentModelObjectType,
 } from "../../../utilities/convertModelsToObject";
 
-const useStyles = makeStyles((theme: any) => ({
+const useStyles = makeStyles()((theme: any) => ({
     gradientContainer: {
         position: "relative",
         height: 40,
         display: "flex",
         alignItems: "center",
     },
-    gradientLeft: () => {
-        const background = `linear-gradient(90deg, ${theme.palette.background.paper} 0%, rgba(0,0,0,0) 100%)`;
-        return {
-            background: background,
-            width: 35,
-            height: "85%",
-            position: "absolute",
-            zIndex: 90,
-        };
+    gradientLeft: {
+        background: `linear-gradient(90deg, ${theme.palette.background.paper} 0%, rgba(0,0,0,0) 100%)`,
+        width: 35,
+        height: "85%",
+        position: "absolute",
+        zIndex: 90,
     },
-    gradientRight: () => {
-        const background = `linear-gradient(90deg, rgba(0,0,0,0) 0%, ${theme.palette.background.paper} 100%)`;
-        return {
-            background: background,
-            width: 35,
-            height: "85%",
-            position: "absolute",
-            right: 0,
-            zIndex: 90,
-        };
+    gradientRight: {
+        background: `linear-gradient(90deg, rgba(0,0,0,0) 0%, ${theme.palette.background.paper} 100%)`,
+        width: 35,
+        height: "85%",
+        position: "absolute",
+        right: 0,
+        zIndex: 90,
     },
 }));
 
 function LeftArrow() {
     const theme = useTheme();
-    const classes = useStyles();
+    const { classes } = useStyles();
     const isSm = useMediaQuery(theme.breakpoints.down("md"));
     const { isFirstItemVisible, isLastItemVisible, scrollPrev } =
         React.useContext(VisibilityContext);
@@ -100,7 +94,7 @@ function LeftArrow() {
 
 function RightArrow() {
     const theme = useTheme();
-    const classes = useStyles();
+    const { classes } = useStyles();
     const isSm = useMediaQuery(theme.breakpoints.down("md"));
     const { isLastItemVisible, isFirstItemVisible, scrollNext } =
         React.useContext(VisibilityContext);

--- a/src/scenes/Dashboard/components/CollaboratorPickerPopover.js
+++ b/src/scenes/Dashboard/components/CollaboratorPickerPopover.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import makeStyles from '@mui/styles/makeStyles';
+import { makeStyles } from 'tss-react/mui';
 import Popover from '@mui/material/Popover';
 import Tooltip from "@mui/material/Tooltip";
 import IconButton from "@mui/material/IconButton";
@@ -10,14 +10,14 @@ import UsersSelect from "../../../components/UsersSelect";
 import {useDispatch} from "react-redux";
 import {SmallCirclePlusButton} from "../../../components/Buttons";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     root: {
         padding: theme.spacing(2),
     }
 }));
 
 export default function CollaboratorPickerPopover(props) {
-    const classes = useStyles();
+    const { classes } = useStyles();
     const [anchorEl, setAnchorEl] = React.useState(null);
     const dispatch = useDispatch();
 

--- a/src/scenes/Dashboard/components/DashboardDetailTabs.tsx
+++ b/src/scenes/Dashboard/components/DashboardDetailTabs.tsx
@@ -3,13 +3,13 @@ import * as selectionModeActions from "../../../redux/selectionMode/selectionMod
 import AddIcon from "@mui/icons-material/Add";
 import Box from "@mui/material/Box";
 import { useDispatch, useSelector } from "react-redux";
+import { makeStyles } from "tss-react/mui";
 import IconButton from "@mui/material/IconButton";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import { saveDashboardRoleMode } from "../../../utilities";
 import Typography from "@mui/material/Typography";
-import { showHide } from "../../../styles/common";
 import {
     setDashboardFilteredUser,
     setDashboardTabIndex,
@@ -44,7 +44,6 @@ const DashboardDetailTabs: React.FC<DashboardDetailTabsProps> = ({
     const whoami = useSelector(getWhoami);
     const dashboardFilter = useSelector(dashboardFilterTermSelector);
     const roleView = useSelector(getRoleView);
-    const { show, hide } = showHide();
     const dashboardFilteredUser = useSelector(dashboardFilteredUserSelector);
     const guidedSetupOpen = useSelector(guidedSetupOpenSelector);
     const theme = useTheme();
@@ -182,11 +181,13 @@ const DashboardDetailTabs: React.FC<DashboardDetailTabsProps> = ({
                     }}
                 >
                     <MenuItem
-                        className={
-                            whoami.roles.includes(models.Role.COORDINATOR)
-                                ? show
-                                : hide
-                        }
+                        sx={{
+                            display: whoami.roles.includes(
+                                models.Role.COORDINATOR
+                            )
+                                ? ""
+                                : "none",
+                        }}
                         onClick={() => {
                             setAnchorElRoleMenu(null);
                             if (roleView !== "ALL") {
@@ -199,11 +200,13 @@ const DashboardDetailTabs: React.FC<DashboardDetailTabsProps> = ({
                         All Tasks
                     </MenuItem>
                     <MenuItem
-                        className={
-                            whoami.roles.includes(models.Role.COORDINATOR)
-                                ? show
-                                : hide
-                        }
+                        sx={{
+                            display: whoami.roles.includes(
+                                models.Role.COORDINATOR
+                            )
+                                ? ""
+                                : "none",
+                        }}
                         onClick={() => {
                             setAnchorElRoleMenu(null);
                             if (roleView !== models.Role.COORDINATOR) {
@@ -216,11 +219,11 @@ const DashboardDetailTabs: React.FC<DashboardDetailTabsProps> = ({
                         Coordinator
                     </MenuItem>
                     <MenuItem
-                        className={
-                            whoami.roles.includes(models.Role.RIDER)
-                                ? show
-                                : hide
-                        }
+                        sx={{
+                            display: whoami.roles.includes(models.Role.RIDER)
+                                ? ""
+                                : "none",
+                        }}
                         onClick={() => {
                             setAnchorElRoleMenu(null);
                             if (roleView !== models.Role.RIDER) {

--- a/src/scenes/Dashboard/components/SideInfoSection.js
+++ b/src/scenes/Dashboard/components/SideInfoSection.js
@@ -1,7 +1,6 @@
 import React from "react";
-import clsx from "clsx";
 import { useTheme } from "@mui/material/styles";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import CssBaseline from "@mui/material/CssBaseline";
 import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
@@ -14,7 +13,7 @@ import Typography from "@mui/material/Typography";
 
 const drawerWidth = 400;
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     root: {
         display: "flex",
     },
@@ -57,13 +56,13 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function SideInfoSection(props) {
-    const classes = useStyles();
+    const { classes, cx } = useStyles();
     const theme = useTheme();
     return (
         <div className={classes.root}>
             <CssBaseline />
             <main
-                className={clsx(classes.content, {
+                className={cx(classes.content, {
                     [classes.contentShift]: props.open,
                 })}
             >

--- a/src/scenes/Dashboard/components/TaskCardsColoured.js
+++ b/src/scenes/Dashboard/components/TaskCardsColoured.js
@@ -7,7 +7,7 @@ import CardItem from "../../../components/CardItem";
 import AvatarGroup from "@mui/material/AvatarGroup";
 import UserAvatar from "../../../components/UserAvatar";
 import { Divider, Stack, Tooltip, Typography } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import { StyledCard } from "../../../styles/common";
 import Badge from "@mui/material/Badge";
 import MessageIcon from "@mui/icons-material/Message";
@@ -30,45 +30,57 @@ const generateClass = (theme, status) => {
     };
 };
 
-const useStyles = makeStyles((theme) => ({
-    cardContent: {
-        paddingTop: 5,
-        userSelect: "none",
-    },
-    NEW: generateClass(theme, "NEW"),
-    ACTIVE: generateClass(theme, "ACTIVE"),
-    PICKED_UP: generateClass(theme, "PICKED_UP"),
-    DROPPED_OFF: generateClass(theme, "DROPPED_OFF"),
-    COMPLETED: generateClass(theme, "COMPLETED"),
-    CANCELLED: generateClass(theme, "CANCELLED"),
-    REJECTED: generateClass(theme, "REJECTED"),
-    ABANDONED: generateClass(theme, "ABANDONED"),
-    itemTopBarContainer: {
-        width: "100%",
-        height: 30,
-        paddingBottom: 10,
-    },
-    divider: { width: "0%", margin: 4 },
-    typography: { fontSize: "14px" },
-    badgeCircle: {
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        width: 32,
-        height: 32,
-        borderRadius: "50%",
-        backgroundColor:
-            theme.palette.mode === "dark"
-                ? "rgba(0,0,0,0.4)"
-                : "rgba(255,255,255,0.5)",
-    },
-}));
+const useStyles = makeStyles()((theme) => {
+    const statuses = {};
+    statuses.NEW = generateClass(theme, "NEW");
+    statuses.ACTIVE = generateClass(theme, "ACTIVE");
+    statuses.PICKED_UP = generateClass(theme, "PICKED_UP");
+    statuses.DROPPED_OFF = generateClass(theme, "DROPPED_OFF");
+    statuses.COMPLETED = generateClass(theme, "COMPLETED");
+    statuses.CANCELLED = generateClass(theme, "CANCELLED");
+    statuses.REJECTED = generateClass(theme, "REJECTED");
+    statuses.ABANDONED = generateClass(theme, "ABANDONED");
+    return {
+        ...statuses,
+        cardContent: {
+            paddingTop: 5,
+            userSelect: "none",
+        },
+        NEW: generateClass(theme, "NEW"),
+        ACTIVE: generateClass(theme, "ACTIVE"),
+        PICKED_UP: generateClass(theme, "PICKED_UP"),
+        DROPPED_OFF: generateClass(theme, "DROPPED_OFF"),
+        COMPLETED: generateClass(theme, "COMPLETED"),
+        CANCELLED: generateClass(theme, "CANCELLED"),
+        REJECTED: generateClass(theme, "REJECTED"),
+        ABANDONED: generateClass(theme, "ABANDONED"),
+        itemTopBarContainer: {
+            width: "100%",
+            height: 30,
+            paddingBottom: 10,
+        },
+        divider: { width: "0%", margin: 4 },
+        typography: { fontSize: "14px" },
+        badgeCircle: {
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            width: 32,
+            height: 32,
+            borderRadius: "50%",
+            backgroundColor:
+                theme.palette.mode === "dark"
+                    ? "rgba(0,0,0,0.4)"
+                    : "rgba(255,255,255,0.5)",
+        },
+    };
+});
 
 const TaskCard = (props) => {
     const assigneesDisplayString = props.assignees
         .map((assignee) => assignee.displayName)
         .join(", ");
-    const classes = useStyles();
+    const { classes } = useStyles();
     let pickUpTitle = "";
     if (props.pickUpLocation) {
         pickUpTitle = props.pickUpLocation.line1

--- a/src/scenes/Dashboard/components/TaskGridColumnHeader.js
+++ b/src/scenes/Dashboard/components/TaskGridColumnHeader.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import * as selectionActions from "../../../redux/selectionMode/selectionModeActions";
 import { Box, IconButton, Stack, Typography } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from 'tss-react/mui';
 import CheckBoxIcon from "@mui/icons-material/CheckBox";
 import IndeterminateCheckBoxIcon from "@mui/icons-material/IndeterminateCheckBox";
 import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
@@ -13,7 +13,7 @@ import {
     selectedItemsSelector,
 } from "../../../redux/Selectors";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     header: {
         fontWeight: "bold",
     },
@@ -32,7 +32,7 @@ function TaskGridColumnHeader(props) {
     const dispatch = useDispatch();
     const dashboardFilter = useSelector(dashboardFilterTermSelector);
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     function handleSelectCheckBoxClick() {
         const selectedItems = selectedItemsAll[tabIndex] || [];

--- a/src/scenes/Dashboard/components/TaskGridTasksList.js
+++ b/src/scenes/Dashboard/components/TaskGridTasksList.js
@@ -6,20 +6,19 @@ import { showHide } from "../../../styles/common";
 import { sortByCreatedTime } from "../../../utilities";
 import TaskItem from "./TaskItem";
 import DateStampDivider from "./TimeStampDivider";
-import clsx from "clsx";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     taskItem: {
         width: "100%",
     },
 });
 
 function TaskGridTasksList(props) {
-    const { show, hide } = showHide();
+    const { show, hide } = showHide().classes;
     let displayDate = false;
     let lastTime = new Date();
-    const classes = useStyles();
+    const { classes, cx } = useStyles();
     const filteredTasksIdsList = props.includeList || [];
     return (
         <Stack
@@ -48,7 +47,7 @@ function TaskGridTasksList(props) {
                     }
                     return (
                         <Box
-                            className={clsx(
+                            className={cx(
                                 classes.taskItem,
                                 props.includeList === null ||
                                     props.includeList.includes(task.id)
@@ -72,7 +71,6 @@ function TaskGridTasksList(props) {
                                 animate={props.animate}
                                 task={task}
                                 taskUUID={task.id}
-                                deleteDisabled
                             />
                         </Box>
                     );

--- a/src/scenes/Dashboard/components/TaskItem.js
+++ b/src/scenes/Dashboard/components/TaskItem.js
@@ -9,7 +9,8 @@ import * as selectionActions from "../../../redux/selectionMode/selectionModeAct
 import { encodeUUID } from "../../../utilities";
 import PropTypes from "prop-types";
 import { Box, Grow, Skeleton, ToggleButton } from "@mui/material";
-import { makeStyles, useTheme } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
+import { useTheme } from "@mui/styles";
 import TaskContextMenu from "../../../components/ContextMenus/TaskContextMenu";
 import { commentVisibility, userRoles } from "../../../apiConsts";
 import * as models from "../../../models/index";
@@ -26,18 +27,22 @@ import {
 import { useInView } from "react-intersection-observer";
 import useLongPressEventContextMenu from "../../../hooks/useLongPressEventContextMenu";
 
-const useStyles = (isSelected) =>
-    makeStyles((theme) => ({
+const useStyles = makeStyles()((theme, { isSelected }, classes) => {
+    const background =
+        theme.palette.mode === "dark"
+            ? "radial-gradient(circle, rgba(64,64,64,1) 30%, rgba(0,0,0,0) 100%)"
+            : `radial-gradient(circle, ${theme.palette.background.paper} 30%, rgba(0,0,0,0) 100%)`;
+    return {
         root: {
             position: "relative",
             "&:hover": {
-                "& $dots": {
+                [`& .${classes.dots}`]: {
                     display: isSelected ? "none" : "inline",
                 },
-                "& $select": {
+                [`& .${classes.select}`]: {
                     display: "inline",
                 },
-                "& $overlay": {
+                [`& .${classes.overlay}`]: {
                     display: "inline",
                     [theme.breakpoints.down("sm")]: {
                         display: isSelected ? "inline" : "none",
@@ -61,40 +66,29 @@ const useStyles = (isSelected) =>
             width: "100%",
             height: "100%",
         },
-        dots: () => {
-            const background =
-                theme.palette.mode === "dark"
-                    ? "radial-gradient(circle, rgba(64,64,64,1) 30%, rgba(0,0,0,0) 100%)"
-                    : `radial-gradient(circle, ${theme.palette.background.paper} 30%, rgba(0,0,0,0) 100%)`;
-            return {
-                background: background,
-                borderRadius: "1em",
-                position: "absolute",
-                bottom: 4,
-                right: 4,
-                display: "none",
-                zIndex: 90,
-            };
+        dots: {
+            background,
+            borderRadius: "1em",
+            position: "absolute",
+            bottom: 4,
+            right: 4,
+            display: "none",
+            zIndex: 90,
         },
-        select: () => {
-            const background =
-                theme.palette.mode === "dark"
-                    ? "radial-gradient(circle, rgba(64,64,64,1) 30%, rgba(0,0,0,0) 100%)"
-                    : `radial-gradient(circle, ${theme.palette.background.paper} 30%, rgba(0,0,0,0) 100%)`;
-            return {
-                background: isSelected
-                    ? theme.palette.background.paper
-                    : background,
-                margin: 2,
-                borderRadius: "1em",
-                position: "absolute",
-                bottom: 4,
-                left: 4,
-                display: isSelected ? "inline" : "none",
-                zIndex: 90,
-            };
+        select: {
+            background: isSelected
+                ? theme.palette.background.paper
+                : background,
+            margin: 2,
+            borderRadius: "1em",
+            position: "absolute",
+            bottom: 4,
+            left: 4,
+            display: isSelected ? "inline" : "none",
+            zIndex: 90,
         },
-    }));
+    };
+});
 
 const ItemWrapper = ({
     children,
@@ -166,7 +160,9 @@ const TaskItem = React.memo((props) => {
     const dispatch = useDispatch();
     const theme = useTheme();
     const isSm = useMediaQuery(theme.breakpoints.down("md"));
-    const classes = useStyles(isSelected)();
+    const { classes } = useStyles({
+        isSelected,
+    });
 
     const { ref, inView } = useInView({
         threshold: 0,
@@ -323,7 +319,6 @@ const TaskItem = React.memo((props) => {
                     <>
                         <div className={classes.dots}>
                             <TaskContextMenu
-                                disableDeleted={props.deleteDisabled}
                                 disableRelay={!!props.relayNext}
                                 assignedRiders={assignedRiders}
                                 task={task}
@@ -362,7 +357,6 @@ TaskItem.defaultProps = {
 TaskItem.propTypes = {
     task: PropTypes.object,
     view: PropTypes.string,
-    deleteDisabled: PropTypes.bool,
     animate: PropTypes.bool,
 };
 

--- a/src/scenes/Dashboard/components/TasksGrid.js
+++ b/src/scenes/Dashboard/components/TasksGrid.js
@@ -2,7 +2,7 @@ import React from "react";
 import _ from "lodash";
 import Grid from "@mui/material/Grid";
 import PropTypes from "prop-types";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import TasksGridColumn from "./TasksGridColumn";
 import { tasksStatus } from "../../../apiConsts";
 import { dashboardFilteredUserSelector } from "../../../redux/Selectors";
@@ -18,7 +18,7 @@ const getColumnTitle = (key) => {
     return key.join(" / ").replace(/_/g, " ");
 };
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     addRelay: {
         visibility: "hidden",
         "&:hover $hoverDiv": {
@@ -46,7 +46,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function TasksGrid(props) {
-    const classes = useStyles();
+    const { classes } = useStyles();
     const dashboardFilteredUser = useSelector(dashboardFilteredUserSelector);
 
     let justifyContent = "flex-start";

--- a/src/scenes/Dashboard/components/TasksGridColumn.js
+++ b/src/scenes/Dashboard/components/TasksGridColumn.js
@@ -4,7 +4,7 @@ import * as models from "../../../models/index";
 import { useSelector } from "react-redux";
 import { Skeleton, Stack, useMediaQuery } from "@mui/material";
 import PropTypes from "prop-types";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import {
     dashboardFilteredUserSelector,
     getRoleView,
@@ -31,7 +31,7 @@ import { useTheme } from "@mui/styles";
 import TaskGridColumnHeader from "./TaskGridColumnHeader";
 import TaskGridTasksList from "./TaskGridTasksList";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     divider: {
         width: "95%",
     },
@@ -89,7 +89,7 @@ function TasksGridColumn(props) {
     });
     const theme = useTheme();
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     const isSm = useMediaQuery(theme.breakpoints.down("sm"));
 

--- a/src/scenes/Dashboard/components/TasksGridColumn.test.js
+++ b/src/scenes/Dashboard/components/TasksGridColumn.test.js
@@ -180,7 +180,7 @@ describe("TasksGridColumn", () => {
             expect(links).toHaveLength(10);
             for (const link of links) {
                 expect(link.firstChild.className).toMatch(
-                    new RegExp(`makeStyles-${taskStatus}`)
+                    new RegExp(`${taskStatus}`)
                 );
             }
         }

--- a/src/scenes/Dashboard/components/TimeStampDivider.js
+++ b/src/scenes/Dashboard/components/TimeStampDivider.js
@@ -2,9 +2,9 @@ import { Divider, Typography } from "@mui/material";
 import moment from "moment";
 import React from "react";
 import PropTypes from "prop-types";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from 'tss-react/mui';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     date: {
         fontStyle: "italic",
         maxWidth: "100%",
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function DateStampDivider(props) {
-    const classes = useStyles();
+    const { classes } = useStyles();
     return (
         <Divider className={classes.date} orientation="horizontal">
             <Typography>

--- a/src/scenes/Deliverables/DeliverableGridSelect.js
+++ b/src/scenes/Deliverables/DeliverableGridSelect.js
@@ -13,7 +13,7 @@ import AddableDeliverable from "./components/AddableDeliverable";
 import _ from "lodash";
 import GetError from "../../ErrorComponents/GetError";
 import DeliverableTags from "./DeliverableTags";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from 'tss-react/mui';
 
 const initialDeliverablesSortedState = {
     deliverables: [],
@@ -28,7 +28,7 @@ const tagsReducer = (previousValue, currentValue = []) => {
     return [...previousValue, ...filtered];
 };
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     hint: {
         fontStyle: "italic",
         fontSize: 15,
@@ -54,7 +54,7 @@ function DeliverableGridSelect(props) {
         dataStoreModelSyncedStatusSelector
     ).DeliverableType;
     const [isFetching, setIsFetching] = useState(false);
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     const calculateTags = React.useCallback((currentTag, defaults) => {
         const existingTags = Object.values(defaults).map(

--- a/src/scenes/Deliverables/components/DeliverableCard.js
+++ b/src/scenes/Deliverables/components/DeliverableCard.js
@@ -1,23 +1,23 @@
 import Typography from "@mui/material/Typography";
 import React from "react";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import PropTypes from "prop-types";
 import { Stack, Tooltip } from "@mui/material";
 import { deliverableIcons } from "../../../apiConsts";
 import { getDeliverableIconByEnum } from "../../../utilities";
 
-const useStyles = makeStyles(() => ({
-    root: (props) => ({
+const useStyles = makeStyles()(({ compact }) => ({
+    root: {
         width: "100%",
         backgroundColor: "rgba(180, 180, 180, 0.1)",
-    }),
-    label: (props) => ({
-        maxWidth: props.compact ? 120 : 200,
-    }),
+    },
+    label: {
+        maxWidth: compact ? 120 : 200,
+    },
 }));
 
 function DeliverableCard(props) {
-    const classes = useStyles(props);
+    const { classes } = useStyles({ compact: props.compact });
     const maxTextLength = props.compact ? 12 : 22;
     return (
         <Stack

--- a/src/scenes/Deliverables/components/DeliverableSelect.js
+++ b/src/scenes/Deliverables/components/DeliverableSelect.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import {useSelector} from "react-redux";
 import FormControl from "@mui/material/FormControl";
 import {InputLabel, MenuItem, Select} from "@mui/material";
-import makeStyles from '@mui/styles/makeStyles';
+import { makeStyles } from 'tss-react/mui';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles()(theme => ({
     formControl: {
         margin: theme.spacing(1),
         width: "100%",
@@ -19,7 +19,7 @@ const useStyles = makeStyles(theme => ({
 
 function DeliverablesSelect(props) {
     const availableDeliverables = useSelector(state => state.availableDeliverables.deliverables)
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     const onSelect = (e) => {
         if (e.target.value)

--- a/src/scenes/Deliverables/components/EditableDeliverable.js
+++ b/src/scenes/Deliverables/components/EditableDeliverable.js
@@ -5,10 +5,10 @@ import IncreaseDecreaseCounter from "../../../components/IncreaseDecreaseCounter
 import UnitSelector from "../../../components/UnitSelector";
 import _ from "lodash";
 import { IconButton, Stack, Tooltip } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import ArchitectureIcon from "@mui/icons-material/Architecture";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     button: {
         width: theme.spacing(4),
         height: theme.spacing(4),
@@ -22,7 +22,7 @@ const useStyles = makeStyles((theme) => ({
 function EditableDeliverable(props) {
     const deliverable = props.deliverable;
     const [showUnit, setShowUnit] = useState(false);
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     function handleCloseUnit() {
         setShowUnit((prevState) => !prevState);

--- a/src/scenes/GuidedSetup/GuidedSetup.js
+++ b/src/scenes/GuidedSetup/GuidedSetup.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import PropTypes from "prop-types";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import AppBar from "@mui/material/AppBar";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
@@ -66,7 +66,7 @@ const a11yProps = (index) => {
     };
 };
 
-const guidedSetupStyles = makeStyles((theme) => ({
+const guidedSetupStyles = makeStyles()((theme) => ({
     wrapper: {
         display: "flex",
         flexDirection: "column",
@@ -134,7 +134,7 @@ const defaultComment = {
 const initialEstablishmentSameAsPickUpState = false;
 
 export const GuidedSetup = () => {
-    const classes = guidedSetupStyles();
+    const { classes } = guidedSetupStyles();
     const [tabIndex, setTabIndex] = React.useState(0);
     const [formValues, setFormValues] = useState(defaultValues);
     const [establishmentSameAsPickup, setEstablishmentSameAsPickup] = useState(
@@ -151,7 +151,7 @@ export const GuidedSetup = () => {
     const dispatch = useDispatch();
     const locations = useRef({ pickUpLocation: null, dropOffLocation: null });
     const [pickUpOverride, setPickUpOverride] = useState(null);
-    const { show, hide } = showHide();
+    const { show, hide } = showHide().classes;
     const [discardConfirmationOpen, setDiscardConfirmationOpen] =
         useState(false);
     const whoami = useSelector(getWhoami);

--- a/src/scenes/GuidedSetup/components/ItemSelector.js
+++ b/src/scenes/GuidedSetup/components/ItemSelector.js
@@ -9,7 +9,7 @@ import {
 import DeliverableCard from "../../../scenes/Deliverables/components/DeliverableCard";
 import DeliverablesSkeleton from "../../../scenes/Deliverables/components/DeliverablesSkeleton";
 import { styled } from "@mui/material/styles";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import Box from "@mui/material/Box";
 import { Paper } from "@mui/material";
 import { dialogCardStyles } from "../../Task/styles/DialogCompactStyles";
@@ -18,7 +18,7 @@ import { v4 as uuidv4 } from "uuid";
 import { SmallCirclePlusButton } from "../../../components/Buttons";
 import { showHide } from "../../../styles/common";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     root: {
         width: "100%",
         maxWidth: 350,
@@ -81,10 +81,15 @@ export default function ItemSelector(props) {
     const loadingSelector = createLoadingSelector(["GET_DELIVERABLES"]);
     const [truncated, setTruncated] = useState(false);
     const isFetching = useSelector((state) => loadingSelector(state));
-    const classes = useStyles();
+    const { classes } = useStyles();
     const cardClasses = dialogCardStyles();
 
-    const { show, hide } = useStyles(showHide);
+    const {
+        show,
+        hide
+    } = useStyles(showHide, {
+        props: showHide
+    });
 
     let emptyDeliverable = {
         task_uuid: props.taskUUID,

--- a/src/scenes/GuidedSetup/components/LocationDropdownSelector.js
+++ b/src/scenes/GuidedSetup/components/LocationDropdownSelector.js
@@ -2,10 +2,10 @@ import React from "react";
 import Grid from "@mui/material/Grid";
 import PropTypes from "prop-types";
 import FavouriteLocationsSelect from "../../../components/FavouriteLocationsSelect";
-import makeStyles from '@mui/styles/makeStyles';
+import { makeStyles } from 'tss-react/mui';
 import { encodeUUID } from "../../../utilities";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     root: {
         width: "100%",
         marginBottom: "30px",
@@ -25,7 +25,7 @@ const useStyles = makeStyles({
 });
 
 export const LocationDropdownSelector = (props) => {
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     const presetName =
         props.location && props.location.name ? props.location.name : "";

--- a/src/scenes/GuidedSetup/components/LocationSelector.js
+++ b/src/scenes/GuidedSetup/components/LocationSelector.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import LabelItemPair from "../../../components/LabelItemPair";
 import ClickableTextField from "../../../components/ClickableTextField";
 import FavouriteLocationsSelect from "../../../components/FavouriteLocationsSelect";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import Divider from "@mui/material/Divider";
 import { Tooltip } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
@@ -14,7 +14,7 @@ import { showHide } from "../../../styles/common";
 import { encodeUUID } from "../../../utilities";
 import ClearButtonWithConfirmation from "../../Task/components/ClearButtonWithConfirmation";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     root: {
         maxWidth: "350px",
     },
@@ -47,11 +47,11 @@ const initialState = {
 };
 
 function LocationSelector(props) {
-    const classes = useStyles();
+    const { classes } = useStyles();
     const [state, setState] = useState(initialState);
     const [protectedLocation, setProtectedLocation] = useState(false);
     const [presetMode, setPresetMode] = useState(false);
-    const { show, hide } = showHide();
+    const { show, hide } = showHide().classes;
 
     function updateStateFromProps() {
         if (props.location) {

--- a/src/scenes/GuidedSetup/components/ManualAddress.js
+++ b/src/scenes/GuidedSetup/components/ManualAddress.js
@@ -3,7 +3,7 @@ import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 import LabelItemPair from "../../../components/LabelItemPair";
 import ClickableTextField from "../../../components/ClickableTextField";
-import makeStyles from '@mui/styles/makeStyles';
+import { makeStyles } from 'tss-react/mui';
 import Divider from "@mui/material/Divider";
 
 const initialState = {
@@ -23,7 +23,7 @@ const initialState = {
     },
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     root: {
         width: "100%",
         padding: "0 5px 30px 5px",
@@ -41,7 +41,7 @@ const useStyles = makeStyles({
 
 
 export const ManualAddress = (props) => {
-    const classes = useStyles();
+    const { classes } = useStyles();
     
     const [state, setState] = useState(initialState);
     const [protectedLocation, setProtectedLocation] = useState(false);

--- a/src/scenes/GuidedSetup/components/NotesAndPriority.js
+++ b/src/scenes/GuidedSetup/components/NotesAndPriority.js
@@ -12,7 +12,7 @@ export const NotesAndPriority = ({
     handleVisibilityChange,
     onChangePriority,
 }) => {
-    const classes = Styles();
+    const { classes } = Styles();
     const [visibility, setVisibility] = useState(commentVisibility.everyone);
 
     return (

--- a/src/scenes/GuidedSetup/components/PopOutLocationSelector.js
+++ b/src/scenes/GuidedSetup/components/PopOutLocationSelector.js
@@ -4,7 +4,7 @@ import _ from "lodash";
 import PropTypes from "prop-types";
 import LabelItemPair from "../../../components/LabelItemPair";
 import FavouriteLocationsSelect from "../../../components/FavouriteLocationsSelect";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import Divider from "@mui/material/Divider";
 import { Box, Button, Stack, Tooltip } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
@@ -14,7 +14,7 @@ import CollapsibleToggle from "../../../components/CollapsibleToggle";
 import PopOutLocationSelectorForm from "./PopoutLocationSelectorForm";
 import { protectedFields } from "../../../apiConsts";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     label: {
         maxWidth: "250px",
     },
@@ -48,7 +48,7 @@ const contactFields = {
 };
 
 function PopOutLocationSelector(props) {
-    const classes = useStyles();
+    const { classes } = useStyles();
     const [state, setState] = useState(null);
     const oldState = useRef(null);
     const [editMode, setEditMode] = useState(false);

--- a/src/scenes/GuidedSetup/styles.js
+++ b/src/scenes/GuidedSetup/styles.js
@@ -1,6 +1,6 @@
-import makeStyles from '@mui/styles/makeStyles';
+import { makeStyles } from "tss-react/mui";
 
-export const Styles = makeStyles(({
+export const Styles = makeStyles()({
     wrapper: {
         marginTop: "30px",
         marginBottom: "30px",
@@ -24,5 +24,5 @@ export const Styles = makeStyles(({
         display: "flex",
         flexDirection: "column",
         alignItems: "flex-end",
-    }
-}));
+    },
+});

--- a/src/scenes/LocationsList.js
+++ b/src/scenes/LocationsList.js
@@ -9,11 +9,11 @@ import { displayErrorNotification } from "../redux/notifications/NotificationsAc
 import { Button, Stack, TextField } from "@mui/material";
 import { Link } from "react-router-dom";
 import { matchSorter } from "match-sorter";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import SearchIcon from "@mui/icons-material/Search";
 import { InputAdornment } from "@mui/material";
 
-const useStyles = makeStyles((theme) => {
+const useStyles = makeStyles()((theme) => {
     return {
         root: {
             [theme.breakpoints.down("md")]: {
@@ -38,7 +38,7 @@ export default function LocationsList() {
     const [filteredLocations, setFilteredLocations] = useState([]);
     const whoami = useSelector(getWhoami);
     const dispatch = useDispatch();
-    const classes = useStyles();
+    const { classes } = useStyles();
     const observer = useRef({ unsubscribe: () => {} });
 
     function onChangeFilterText(e) {

--- a/src/scenes/Statistics/StatisticsDashboard.js
+++ b/src/scenes/Statistics/StatisticsDashboard.js
@@ -3,7 +3,7 @@ import { PaddedPaper } from "../../styles/common";
 import TasksStatistics from "./components/TasksStatistics";
 import CircularProgress from "@mui/material/CircularProgress";
 import { useDispatch, useSelector } from "react-redux";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import FormControl from "@mui/material/FormControl";
 import { Fade, InputLabel, MenuItem, Select, Stack } from "@mui/material";
 import { getWhoami } from "../../redux/Selectors";
@@ -13,7 +13,7 @@ import moment from "moment";
 import UserRoleSelect from "../../components/UserRoleSelect";
 import { displayErrorNotification } from "../../redux/notifications/NotificationsActions";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     formControl: {
         margin: theme.spacing(1),
         minWidth: 120,
@@ -44,7 +44,7 @@ const initialState = {
 
 function StatisticsDashboard() {
     const [state, setState] = useState(initialState);
-    const classes = useStyles();
+    const { classes } = useStyles();
     const [isFetching, setIsFetching] = useState(false);
     const whoami = useSelector(getWhoami);
     const [role, setRole] = useState(userRoles.coordinator);

--- a/src/scenes/Task/TaskDialogCompact.js
+++ b/src/scenes/Task/TaskDialogCompact.js
@@ -4,7 +4,7 @@ import Dialog from "@mui/material/Dialog";
 import { useDispatch, useSelector } from "react-redux";
 import { decodeUUID } from "../../utilities";
 import { useTheme } from "@mui/material/styles";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import useMediaQuery from "@mui/material/useMediaQuery";
 import NotFound from "../../ErrorComponents/NotFound";
 import GetError from "../../ErrorComponents/GetError";
@@ -21,7 +21,7 @@ import { setSelectionActionsPending } from "../../redux/selectionMode/selectionM
 const drawerWidth = 420;
 const drawerWidthMd = 420;
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     paper: {
         boxShadow: "none",
         background: theme.palette.background.default,
@@ -46,7 +46,7 @@ const useStyles = makeStyles((theme) => ({
 
 const DialogWrapper = (props) => {
     const { handleClose } = props;
-    const classes = useStyles();
+    const { classes } = useStyles();
     return (
         <Dialog
             onKeyUp={(e) => {
@@ -73,7 +73,7 @@ const DialogWrapper = (props) => {
 
 function TaskDialogCompact(props) {
     const [notFound, setNotFound] = useState(false);
-    const classes = useStyles();
+    const { classes } = useStyles();
     const theme = useTheme();
     const isMd = useMediaQuery(theme.breakpoints.down("lg"));
     const taskObserver = useRef({ unsubscribe: () => {} });

--- a/src/scenes/Task/components/ActivityPopover.js
+++ b/src/scenes/Task/components/ActivityPopover.js
@@ -1,6 +1,6 @@
 import Popover from "@mui/material/Popover";
 import React from "react";
-import makeStyles from '@mui/styles/makeStyles';
+import { makeStyles } from 'tss-react/mui';
 import Button from "@mui/material/Button";
 import ActionsRecord from "../../ActionsRecord/ActionsRecord";
 import PropTypes from "prop-types"

--- a/src/scenes/Task/components/AssignRiderCoordinatorPopover.js
+++ b/src/scenes/Task/components/AssignRiderCoordinatorPopover.js
@@ -7,23 +7,22 @@ import Grid from "@mui/material/Grid";
 import CloseIcon from "@mui/icons-material/Close";
 import IconButton from "@mui/material/IconButton";
 import { Tooltip } from "@mui/material";
-import makeStyles from '@mui/styles/makeStyles';
-import clsx from "clsx";
+import { makeStyles } from "tss-react/mui";
 import { AddCircleOutline } from "@mui/icons-material";
 import { userRoles } from "../../../apiConsts";
 
-const useStyles = makeStyles((theme) => ({
-    button: (props) => ({
-        color: props.iconColor,
+const useStyles = makeStyles()((theme, { iconColor }) => ({
+    button: {
+        color: iconColor,
         width: theme.spacing(4),
         height: theme.spacing(4),
-    }),
+    },
 }));
 
 function AssignRiderCoordinatorPopover(props) {
-    const { show, hide } = showHide();
+    const { show, hide } = showHide().classes;
     const [open, setOpen] = React.useState(false);
-    const classes = useStyles(props);
+    const { classes, cx } = useStyles({ iconColor: props.iconColor });
     const onSelect = (user) => {
         props.onSelect(
             user,
@@ -48,7 +47,8 @@ function AssignRiderCoordinatorPopover(props) {
                 aria-controls="long-menu"
                 aria-haspopup="true"
                 onClick={handleOpen}
-                size="large">
+                size="large"
+            >
                 <AddCircleOutline className={classes.button} />
             </IconButton>
         </Tooltip>
@@ -70,7 +70,7 @@ function AssignRiderCoordinatorPopover(props) {
                 <Grid item>
                     <CoordinatorPicker
                         size={"small"}
-                        className={clsx(open ? show : hide, classes.button)}
+                        className={cx(open ? show : hide, classes.button)}
                         exclude={props.exclude}
                         onSelect={onSelect}
                         label={"Select coordinator"}
@@ -90,7 +90,7 @@ function AssignRiderCoordinatorPopover(props) {
             >
                 <Grid item>
                     <RiderPicker
-                        className={clsx(open ? show : hide, classes.button)}
+                        className={cx(open ? show : hide, classes.button)}
                         exclude={props.exclude}
                         onSelect={onSelect}
                         size={"small"}

--- a/src/scenes/Task/components/AssigneeEditPopover.js
+++ b/src/scenes/Task/components/AssigneeEditPopover.js
@@ -2,15 +2,14 @@ import IconButton from "@mui/material/IconButton";
 import EditIcon from "@mui/icons-material/Edit";
 import React from "react";
 import { Popover } from "@mui/material";
-import makeStyles from '@mui/styles/makeStyles';
+import { makeStyles } from "tss-react/mui";
 import TaskAssignees from "./TaskAssignees";
 import PropTypes from "prop-types";
 import { showHide } from "../../../styles/common";
-import clsx from "clsx";
 
 function AssigneeEditPopover(props) {
     const [anchorEl, setAnchorEl] = React.useState(null);
-    const { show, hide } = showHide();
+    const { show, hide } = showHide().classes;
 
     const handleClick = (event) => {
         setAnchorEl(event.currentTarget);
@@ -23,39 +22,41 @@ function AssigneeEditPopover(props) {
     const open = Boolean(anchorEl);
     const id = open ? "simple-popover" : undefined;
 
-    const useStyles = makeStyles({
+    const useStyles = makeStyles()({
         button: {
             color: props.iconColor,
         },
     });
-    const classes = useStyles();
+    const { classes, cx } = useStyles();
 
-    return <>
-        <IconButton onClick={handleClick} size="large">
-            <EditIcon
-                className={clsx(
-                    classes.button,
-                    props.assignees.length === 0 ? hide : show
-                )}
-            />
-        </IconButton>
-        <Popover
-            id={id}
-            open={open}
-            anchorEl={anchorEl}
-            onClose={handleClose}
-            anchorOrigin={{
-                vertical: "bottom",
-                horizontal: "center",
-            }}
-            transformOrigin={{
-                vertical: "top",
-                horizontal: "center",
-            }}
-        >
-            <TaskAssignees {...props} onRemove={handleClose} />
-        </Popover>
-    </>;
+    return (
+        <>
+            <IconButton onClick={handleClick} size="large">
+                <EditIcon
+                    className={cx(
+                        classes.button,
+                        props.assignees.length === 0 ? hide : show
+                    )}
+                />
+            </IconButton>
+            <Popover
+                id={id}
+                open={open}
+                anchorEl={anchorEl}
+                onClose={handleClose}
+                anchorOrigin={{
+                    vertical: "bottom",
+                    horizontal: "center",
+                }}
+                transformOrigin={{
+                    vertical: "top",
+                    horizontal: "center",
+                }}
+            >
+                <TaskAssignees {...props} onRemove={handleClose} />
+            </Popover>
+        </>
+    );
 }
 
 AssigneeEditPopover.propTypes = {

--- a/src/scenes/Task/components/DeliverableDetails.js
+++ b/src/scenes/Task/components/DeliverableDetails.js
@@ -19,7 +19,7 @@ import { deliverableUnits, userRoles } from "../../../apiConsts";
 import { useAssignmentRole } from "../../../hooks/useAssignmentRole";
 
 function DeliverableDetails(props) {
-    const cardClasses = dialogCardStyles();
+    const { classes } = dialogCardStyles();
     const [collapsed, setCollapsed] = useState(true);
     const [state, setState] = useState({});
     const tenantId = useSelector(tenantIdSelector);
@@ -238,7 +238,7 @@ function DeliverableDetails(props) {
         return <GetError />;
     } else {
         return (
-            <Paper className={cardClasses.root}>
+            <Paper className={classes.root}>
                 <Stack
                     direction={"column"}
                     justifyContent={"center"}

--- a/src/scenes/Task/components/LocationDetailAndSelector.js
+++ b/src/scenes/Task/components/LocationDetailAndSelector.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import LabelItemPair from "../../../components/LabelItemPair";
 import ClickableTextField from "../../../components/ClickableTextField";
 import FavouriteLocationsSelect from "../../../components/FavouriteLocationsSelect";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import Divider from "@mui/material/Divider";
 import { Box, Stack, Tooltip } from "@mui/material";
 import { ThemedLink } from "../../../styles/common";
@@ -12,7 +12,7 @@ import { encodeUUID } from "../../../utilities";
 import ClearButtonWithConfirmation from "../../../components/ClearButtonWithConfirmation";
 import CollapsibleToggle from "../../../components/CollapsibleToggle";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     root: {},
     label: {
         width: "90%",
@@ -64,7 +64,7 @@ const contactFields = {
 };
 
 function LocationDetailAndSelector(props) {
-    const classes = useStyles();
+    const { classes } = useStyles();
     const [state, setState] = useState(initialState);
     const [collapsed, setCollapsed] = useState(true);
 

--- a/src/scenes/Task/components/LocationDetailsPanel.js
+++ b/src/scenes/Task/components/LocationDetailsPanel.js
@@ -18,7 +18,7 @@ import { useAssignmentRole } from "../../../hooks/useAssignmentRole";
 import ConfirmationDialog from "../../../components/ConfirmationDialog";
 
 function LocationDetailsPanel(props) {
-    const classes = dialogCardStyles();
+    const { classes } = dialogCardStyles();
     const dispatch = useDispatch();
     // I have no idea why the imported selector is undefined here
     const tenantId = useSelector((state) => state.tenantId);

--- a/src/scenes/Task/components/RequesterContact.js
+++ b/src/scenes/Task/components/RequesterContact.js
@@ -10,11 +10,12 @@ import EditIcon from "@mui/icons-material/Edit";
 import ClickableTextField from "../../../components/ClickableTextField";
 import LabelItemPair from "../../../components/LabelItemPair";
 import PropTypes from "prop-types";
-import { makeStyles, useTheme } from "@mui/styles";
+import { makeStyles } from 'tss-react/mui';
+import { useTheme } from '@mui/styles';
 import ConfirmationDialog from "../../../components/ConfirmationDialog";
 import { TextFieldControlled } from "../../../components/TextFields";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     inset: {
         marginLeft: 20,
     },
@@ -49,7 +50,7 @@ function RequesterContact(props) {
         });
     };
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <Stack>

--- a/src/scenes/Task/components/StatusBar.js
+++ b/src/scenes/Task/components/StatusBar.js
@@ -8,7 +8,7 @@ import { taskStatusHumanReadable } from "../../../utilities";
 
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import IconButton from "@mui/material/IconButton";
 import { useDispatch, useSelector } from "react-redux";
 import { displayErrorNotification } from "../../../redux/notifications/NotificationsActions";
@@ -57,19 +57,19 @@ const generateClass = (theme, status) => {
     }
 };
 
-const dialogComponent = (status) =>
-    makeStyles((theme) => {
-        return {
-            root: generateClass(theme, status),
-            statusText: {
-                fontWeight: "bold",
-                color: theme.palette.mode === "dark" ? "white" : "black",
-            },
-            items: {
-                marginTop: 5,
-            },
-        };
-    });
+const useStyles = makeStyles()((theme, { status }) => {
+    const root = generateClass(theme, status);
+    return {
+        root,
+        statusText: {
+            fontWeight: "bold",
+            color: theme.palette.mode === "dark" ? "white" : "black",
+        },
+        items: {
+            marginTop: 5,
+        },
+    };
+});
 
 function StatusBar(props) {
     const [copied, setCopied] = useState(null);
@@ -81,7 +81,7 @@ function StatusBar(props) {
     ).Task;
     const taskObserver = useRef({ unsubscribe: () => {} });
     const [status, setStatus] = useState(null);
-    const classes = dialogComponent(status)();
+    const { classes } = useStyles({ status });
 
     const getTask = React.useCallback(async (taskId) => {
         try {

--- a/src/scenes/Task/components/TaskActions.js
+++ b/src/scenes/Task/components/TaskActions.js
@@ -56,7 +56,7 @@ function TaskActions(props) {
 
     const taskObserver = useRef({ unsubscribe: () => {} });
     const dispatch = useDispatch();
-    const cardClasses = dialogCardStyles();
+    const { classes } = dialogCardStyles();
     const taskModelsSynced = useSelector(
         dataStoreModelSyncedStatusSelector
     ).Task;
@@ -223,7 +223,7 @@ function TaskActions(props) {
     } else {
         return (
             <>
-                <Paper className={cardClasses.root}>
+                <Paper className={classes.root}>
                     <Stack direction={"column"} spacing={2}>
                         <Typography variant={"h6"}>Actions</Typography>
                         <Divider />

--- a/src/scenes/Task/components/TaskAssignmentsPanel.js
+++ b/src/scenes/Task/components/TaskAssignmentsPanel.js
@@ -13,7 +13,6 @@ import {
     Typography,
 } from "@mui/material";
 import PropTypes from "prop-types";
-import makeStyles from "@mui/styles/makeStyles";
 import { tasksStatus, userRoles } from "../../../apiConsts";
 import RiderPicker from "../../../components/RiderPicker";
 import CoordinatorPicker from "../../../components/CoordinatorPicker";
@@ -38,12 +37,6 @@ import GetError from "../../../ErrorComponents/GetError";
 import UserChip from "../../../components/UserChip";
 import RecentlyAssignedUsers from "../../../components/RecentlyAssignedUsers";
 import { useAssignmentRole } from "../../../hooks/useAssignmentRole";
-
-export const useStyles = makeStyles(() => ({
-    italic: {
-        fontStyle: "italic",
-    },
-}));
 
 const sortByUserRole = (a, b) => {
     // coordinators first and riders second

--- a/src/scenes/Task/components/TaskDetailsPanel.js
+++ b/src/scenes/Task/components/TaskDetailsPanel.js
@@ -19,7 +19,7 @@ import { useAssignmentRole } from "../../../hooks/useAssignmentRole";
 import RiderResponsibilityDetail from "./RiderResponsibilityDetail";
 
 function TaskDetailsPanel(props) {
-    const cardClasses = dialogCardStyles();
+    const { classes } = dialogCardStyles();
     const [state, setState] = useState({
         reference: null,
         timeOfCall: null,
@@ -177,13 +177,13 @@ function TaskDetailsPanel(props) {
         return <GetError />;
     } else if (isFetching) {
         return (
-            <Paper className={cardClasses.root}>
+            <Paper className={classes.root}>
                 <Skeleton variant="rectangular" width="100%" height={200} />
             </Paper>
         );
     } else {
         return (
-            <Paper className={cardClasses.root}>
+            <Paper className={classes.root}>
                 <Stack direction={"column"} spacing={1}>
                     {state.reference && (
                         <LabelItemPair label={"Reference"}>

--- a/src/scenes/Task/components/TaskOverview.js
+++ b/src/scenes/Task/components/TaskOverview.js
@@ -5,7 +5,7 @@ import Grid from "@mui/material/Grid";
 import TaskDetailsPanel from "./TaskDetailsPanel";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
-import { makeStyles } from 'tss-react/mui';
+import { makeStyles } from "tss-react/mui";
 import DeliverableDetails from "./DeliverableDetails";
 import TaskActions from "./TaskActions";
 import { Hidden, Stack } from "@mui/material";
@@ -47,12 +47,7 @@ function TaskOverview({ taskId, isFetching }) {
 
     return (
         <Container className={classes.root}>
-            <Grid
-                container
-                direction="row"
-                className={classes.container}
-                spacing={isSm ? 1 : 3}
-            >
+            <Grid container direction="row" spacing={isSm ? 1 : 3}>
                 <Grid item className={classes.item}>
                     <Stack direction={"column"} spacing={isSm ? 1 : 3}>
                         <TaskDetailsPanel

--- a/src/scenes/Task/components/TaskOverview.js
+++ b/src/scenes/Task/components/TaskOverview.js
@@ -5,7 +5,7 @@ import Grid from "@mui/material/Grid";
 import TaskDetailsPanel from "./TaskDetailsPanel";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import DeliverableDetails from "./DeliverableDetails";
 import TaskActions from "./TaskActions";
 import { Hidden, Stack } from "@mui/material";
@@ -13,7 +13,7 @@ import LocationDetailsPanel from "./LocationDetailsPanel";
 import TaskAssignmentsPanel from "./TaskAssignmentsPanel";
 import CommentsSection from "../../Comments/CommentsSection";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     root: {
         maxWidth: 1800,
         padding: 15,
@@ -41,7 +41,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function TaskOverview({ taskId, isFetching }) {
-    const classes = useStyles();
+    const { classes } = useStyles();
     const theme = useTheme();
     const isSm = useMediaQuery(theme.breakpoints.down("sm"));
 

--- a/src/scenes/Task/components/TimeAndNamePicker.js
+++ b/src/scenes/Task/components/TimeAndNamePicker.js
@@ -6,11 +6,11 @@ import Moment from "react-moment";
 import IconButton from "@mui/material/IconButton";
 import { Stack, Tooltip } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import moment from "moment";
 import TimeAndNamePickerDialog from "./TimeAndNamePickerDialog";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     button: {
         height: 9,
     },
@@ -20,7 +20,7 @@ const useStyles = makeStyles({
 });
 
 function TimeAndNamePicker(props) {
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     // check if props.time is today
     function isToday() {

--- a/src/scenes/Task/components/TimePicker.js
+++ b/src/scenes/Task/components/TimePicker.js
@@ -7,14 +7,13 @@ import CancelIcon from "@mui/icons-material/Cancel";
 import IconButton from "@mui/material/IconButton";
 import { Stack, TextField, Tooltip, useMediaQuery } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
-import { showHide } from "../../../styles/common";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import { DateTimePicker } from "@mui/lab";
 import moment from "moment";
 import ConfirmationDialog from "../../../components/ConfirmationDialog";
 import { useTheme } from "@mui/styles";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
     button: {
         height: 9,
     },
@@ -25,10 +24,9 @@ const useStyles = makeStyles({
 
 function TimePicker(props) {
     const [state, setState] = useState(new Date(props.time));
-    const classes = useStyles();
+    const { classes } = useStyles();
     const theme = useTheme();
     const isSm = useMediaQuery(theme.breakpoints.down("sm"));
-    const { show, hide } = showHide();
 
     function onClear() {
         props.onChange(null);
@@ -94,7 +92,7 @@ function TimePicker(props) {
                                     <EditIcon />
                                 </IconButton>
                             </Tooltip>
-                            <div className={props.disableClear ? hide : show}>
+                            {!props.disableClear && (
                                 <Tooltip title={"Clear"}>
                                     <IconButton
                                         aria-label={"Clear"}
@@ -106,7 +104,7 @@ function TimePicker(props) {
                                         <CancelIcon />
                                     </IconButton>
                                 </Tooltip>
-                            </div>
+                            )}
                         </>
                     )}
                 </Stack>

--- a/src/scenes/Task/styles/DialogCompactStyles.js
+++ b/src/scenes/Task/styles/DialogCompactStyles.js
@@ -1,6 +1,6 @@
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 
-export const dialogCardStyles = makeStyles((theme) => ({
+export const dialogCardStyles = makeStyles()((theme) => ({
     root: {
         padding: 15,
         width: "100%",

--- a/src/scenes/UsersList.js
+++ b/src/scenes/UsersList.js
@@ -13,10 +13,10 @@ import { userRoles } from "../apiConsts";
 import { TextFieldControlled } from "../components/TextFields";
 import SearchIcon from "@mui/icons-material/Search";
 import { InputAdornment } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 import { matchSorter } from "match-sorter";
 
-const useStyles = makeStyles((theme) => {
+const useStyles = makeStyles()((theme) => {
     return {
         root: {
             [theme.breakpoints.down("md")]: {
@@ -37,7 +37,7 @@ export default function UsersList() {
     const observer = useRef({ unsubscribe: () => {} });
     const whoami = useSelector(getWhoami);
     const dispatch = useDispatch();
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     function onChangeFilterText(e) {
         setFilteredUsers(

--- a/src/scenes/VehiclesList.js
+++ b/src/scenes/VehiclesList.js
@@ -14,9 +14,9 @@ import { TextFieldControlled } from "../components/TextFields";
 import SearchIcon from "@mui/icons-material/Search";
 import { InputAdornment } from "@mui/material";
 import { matchSorter } from "match-sorter";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from 'tss-react/mui';
 
-const useStyles = makeStyles((theme) => {
+const useStyles = makeStyles()((theme) => {
     return {
         root: {
             [theme.breakpoints.down("md")]: {
@@ -35,7 +35,7 @@ function VehicleList() {
     const whoami = useSelector(getWhoami);
     const vehiclesRef = useRef([]);
     const [filteredVehicles, setFilteredVehicles] = useState([]);
-    const classes = useStyles();
+    const { classes } = useStyles();
     const vehiclesObserver = useRef({ unsubscribe: () => {} });
 
     function onChangeFilterText(e) {

--- a/src/styles/common.js
+++ b/src/styles/common.js
@@ -3,7 +3,7 @@ import "../App.css";
 import Card from "@mui/material/Card";
 import { styled } from "@mui/styles";
 
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 import withTheme from "@mui/styles/withTheme";
 import { Paper } from "@mui/material";
 import Box from "@mui/material/Box";
@@ -11,7 +11,7 @@ import { Link } from "react-router-dom";
 import IconButton from "@mui/material/IconButton";
 import ClearIcon from "@mui/icons-material/Clear";
 
-export const showHide = makeStyles({
+export const showHide = makeStyles()({
     hide: {
         display: "none",
     },
@@ -93,13 +93,3 @@ export function PaddedPaper(props) {
         </Paper>
     );
 }
-
-export const contextDots = makeStyles({
-    root: {
-        cursor: "context-menu",
-        position: "absolute",
-        bottom: 0,
-        right: 0,
-        zIndex: 1000,
-    },
-});


### PR DESCRIPTION
This pull request swaps out makeStyles imported from material UI and replaces it with makeStyles from the tss-react package.

This should improve performance and reduce or eliminate slowdown of the app over time.

makeStyles is left over from MUI V4 and apparently has problems with memory leaks and slow performance.

tss-react provides an almost drop in replacement and a script for automatically updating the code.

I'd like to test this build more to make sure there are no unintended side-effects or issues with the layout, but I think it should be merged before we do any live shifts (we only have training planned for now so that gives some time).

A temporary demo build with the changes: https://dev.d43cb9esdfjwv.amplifyapp.com/