### PR TITLE
Guided setup time of call field

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { makeStyles } from 'tss-react/mui';
+import { makeStyles } from "tss-react/mui";
 import { TextFieldUncontrolled } from "./TextFields";
 
 const useStyles = makeStyles()((theme) => ({
@@ -18,9 +18,23 @@ const useStyles = makeStyles()((theme) => ({
 
 const fields = { name: "Name", telephoneNumber: "Telephone" };
 
-export const ContactForm = ({ values, onChange, italicTel }) => {
-    const { classes } = useStyles();
+type ValuesType = {
+    name: string;
+    telephoneNumber: string;
+};
 
+type ContactFormProps = {
+    onChange: (contact: any) => void;
+    values: ValuesType;
+    italicTel: boolean;
+};
+
+export const ContactForm: React.FC<ContactFormProps> = ({
+    values,
+    onChange,
+    italicTel,
+}) => {
+    const { classes } = useStyles();
     return (
         <form className={classes.root} noValidate autoComplete="off">
             {Object.entries(fields).map(([key, value]) => (
@@ -38,8 +52,11 @@ export const ContactForm = ({ values, onChange, italicTel }) => {
                     fullWidth
                     tel={key === "telephoneNumber"}
                     label={value}
-                    value={values[key]}
-                    onChange={(e) => onChange({ [key]: e.target.value })}
+                    value={(values as any)[key]}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        const { value } = e.target;
+                        onChange({ [key]: value });
+                    }}
                     variant="outlined"
                 />
             ))}

--- a/src/scenes/GuidedSetup/GuidedSetup.js
+++ b/src/scenes/GuidedSetup/GuidedSetup.js
@@ -466,7 +466,7 @@ export const GuidedSetup = () => {
                     <Button
                         data-cy="save-to-dash-button"
                         onClick={handleSave}
-                        disabled={isPosting || timeOfCallInvalid}
+                        disabled={isPosting || !timeOfCall || timeOfCallInvalid}
                         variant="contained"
                         autoFocus
                     >

--- a/src/scenes/GuidedSetup/GuidedSetup.js
+++ b/src/scenes/GuidedSetup/GuidedSetup.js
@@ -147,7 +147,9 @@ export const GuidedSetup = () => {
     const deliverables = useRef({});
     const requesterContact = useRef(defaultContact);
     const comment = useRef(defaultComment);
-    const timeOfCall = useRef(new Date().toISOString());
+    const [timeOfCall, setTimeOfCall] = useState(new Date());
+    const [timeOfCallInvalid, setTimeOfCallInvalid] = useState(false);
+    const originalTimeOfCall = useRef(null);
     const dispatch = useDispatch();
     const locations = useRef({ pickUpLocation: null, dropOffLocation: null });
     const [pickUpOverride, setPickUpOverride] = useState(null);
@@ -204,6 +206,7 @@ export const GuidedSetup = () => {
     const handleSave = async () => {
         setIsPosting(true);
         try {
+            console.log(timeOfCall);
             await saveNewTaskToDataStore(
                 {
                     ...formValues,
@@ -211,7 +214,10 @@ export const GuidedSetup = () => {
                     locations: locations.current,
                     requesterContact: requesterContact.current,
                     comment: comment.current,
-                    timeOfCall: timeOfCall.current,
+                    timeOfCall:
+                        timeOfCall?.toISOString() ||
+                        originalTimeOfCall.current?.toISOString() ||
+                        new Date().toISOString(),
                 },
                 tenantId,
                 whoami && whoami.id
@@ -231,6 +237,7 @@ export const GuidedSetup = () => {
 
     const handleDiscard = React.useCallback(() => {
         if (
+            originalTimeOfCall.current !== timeOfCall ||
             !_.isEqual(formValues, defaultValues) ||
             !_.isEqual(requesterContact.current, defaultContact) ||
             !_.isEqual(comment.current.body, defaultComment.body) ||
@@ -244,6 +251,7 @@ export const GuidedSetup = () => {
         }
     }, [
         formValues,
+        timeOfCall,
         deliverables,
         locations,
         requesterContact,
@@ -264,6 +272,10 @@ export const GuidedSetup = () => {
     function setLocation(key, location) {
         locations.current[key] = location;
     }
+
+    const handleTimeOfCallChange = (value) => {
+        setTimeOfCall(value);
+    };
 
     const handleDeliverablesChange = (value) => {
         if (!value || !value.id) {
@@ -294,7 +306,9 @@ export const GuidedSetup = () => {
 
     useEffect(() => {
         if (guidedSetupOpen) {
-            timeOfCall.current = new Date().toISOString();
+            const newTimeOfCall = new Date();
+            setTimeOfCall(newTimeOfCall);
+            originalTimeOfCall.current = newTimeOfCall;
         } else {
             setFormValues(defaultValues);
             deliverables.current = {};
@@ -359,6 +373,7 @@ export const GuidedSetup = () => {
                     <Box className={tabIndex === 0 ? show : hide}>
                         <CallerDetails
                             values={formValues}
+                            timeOfCall={timeOfCall}
                             establishmentSameAsPickup={
                                 establishmentSameAsPickup
                             }
@@ -367,6 +382,11 @@ export const GuidedSetup = () => {
                             onChangeEstablishmentSameAsPickUp={
                                 handleEstablishmentSameAsPickupChange
                             }
+                            onChangeTimeOfCall={handleTimeOfCallChange}
+                            onInvalidTimeOfCall={(error) => {
+                                if (error) setTimeOfCallInvalid(true);
+                                else setTimeOfCallInvalid(false);
+                            }}
                         />
                     </Box>
                     <Box className={tabIndex === 1 ? show : hide}>
@@ -446,7 +466,7 @@ export const GuidedSetup = () => {
                     <Button
                         data-cy="save-to-dash-button"
                         onClick={handleSave}
-                        disabled={isPosting}
+                        disabled={isPosting || timeOfCallInvalid}
                         variant="contained"
                         autoFocus
                     >

--- a/src/scenes/GuidedSetup/components/CallerDetails.tsx
+++ b/src/scenes/GuidedSetup/components/CallerDetails.tsx
@@ -90,7 +90,19 @@ export const CallerDetails: React.FC<CallerDetailType> = ({
             </Typography>
             <DateTimePicker
                 label="Time of call"
-                renderInput={(params) => <TextField {...params} />}
+                ampm={false}
+                renderInput={(params) => {
+                    const { inputProps } = params;
+                    return (
+                        <TextField
+                            {...params}
+                            inputProps={{
+                                ...inputProps,
+                                "aria-label": "Time of call",
+                            }}
+                        />
+                    );
+                }}
                 value={timeOfCall}
                 onChange={onChangeTimeOfCall}
                 onError={onInvalidTimeOfCall}

--- a/src/scenes/GuidedSetup/components/CallerDetails.tsx
+++ b/src/scenes/GuidedSetup/components/CallerDetails.tsx
@@ -1,21 +1,44 @@
-import { Stack, Typography } from "@mui/material";
+import { DateTimePicker } from "@mui/lab";
+import * as models from "../../../models";
+import { Stack, TextField, Typography } from "@mui/material";
 import React from "react";
 import { ContactForm } from "../../../components/ContactForm";
 import EstablishmentDetails from "./EstablishmentDetails";
 
-export const CallerDetails = ({
+type CallerDetailType = {
+    onChangeContact: (contact: any) => void;
+    onChangeLocation: (location: any) => void;
+    establishmentSameAsPickup: boolean;
+    onChangeEstablishmentSameAsPickUp: (
+        establishmentSameAsPickup: boolean
+    ) => void;
+    timeOfCall: Date;
+    onChangeTimeOfCall: (timeOfCall: Date | null) => void;
+    onInvalidTimeOfCall: (error: any) => void;
+};
+
+type StateType = {
+    name: string;
+    telephoneNumber: string;
+    establishment: null | models.Location;
+};
+
+export const CallerDetails: React.FC<CallerDetailType> = ({
     onChangeContact,
     onChangeLocation,
     establishmentSameAsPickup,
     onChangeEstablishmentSameAsPickUp,
+    onChangeTimeOfCall,
+    timeOfCall,
+    onInvalidTimeOfCall,
 }) => {
-    const [state, setState] = React.useState({
+    const [state, setState] = React.useState<StateType>({
         name: "",
         telephoneNumber: "",
         establishment: null,
     });
 
-    const handleSelectLocation = (location) => {
+    const handleSelectLocation = (location: models.Location) => {
         onChangeLocation(location);
         if (
             !state.telephoneNumber &&
@@ -25,8 +48,8 @@ export const CallerDetails = ({
         ) {
             setState((prevState) => ({
                 ...prevState,
-                establishment: location,
-                telephoneNumber: location.contact.telephoneNumber,
+                establishment: location || null,
+                telephoneNumber: location.contact?.telephoneNumber || "",
             }));
             onChangeContact({
                 name: state.name,
@@ -65,6 +88,13 @@ export const CallerDetails = ({
             <Typography variant="h6">
                 What are their contact details?
             </Typography>
+            <DateTimePicker
+                label="Time of call"
+                renderInput={(params) => <TextField {...params} />}
+                value={timeOfCall}
+                onChange={onChangeTimeOfCall}
+                onError={onInvalidTimeOfCall}
+            />
             <EstablishmentDetails
                 sameAsPickUp={establishmentSameAsPickup}
                 value={state.establishment}
@@ -76,11 +106,8 @@ export const CallerDetails = ({
             <ContactForm
                 values={state}
                 italicTel={
-                    state.establishment &&
-                    state.establishment.contact &&
-                    state.establishment.contact.telephoneNumber &&
                     state.telephoneNumber ===
-                        state.establishment.contact.telephoneNumber
+                    state.establishment?.contact?.telephoneNumber
                 }
                 onChange={(value) => {
                     setState((prevState) => ({ ...prevState, ...value }));


### PR DESCRIPTION
Adds a field to the guided setup for changing the time of call.

![image](https://user-images.githubusercontent.com/32309223/220247267-8abee8a5-dfd4-4d17-8aed-276a1f40f522.png)

Disables the `SAVE TO DASHBOARD` button if the time is invalid or if it is empty.

Defaults to the time that the guided setup is opened and confirms with the user if the time is changed and `DISCARD` button pressed.