### PR TITLE
Clear stale DataStore data

### DIFF
--- a/src/redux/awsHubListener/awsHubListenerSagas.js
+++ b/src/redux/awsHubListener/awsHubListenerSagas.js
@@ -15,6 +15,15 @@ function listener() {
     });
 }
 
+const setLastSyncedDate = () => {
+    const dateLastSynced = new Date().toISOString().split("T")[0];
+    localStorage.setItem("dateLastSynced", dateLastSynced);
+};
+
+const clearLastSyncedDate = () => {
+    localStorage.removeItem("dateLastSynced");
+};
+
 function* initialiseDataStoreListener() {
     if (
         process.env.NODE_ENV === "test" ||
@@ -39,8 +48,20 @@ function* initialiseDataStoreListener() {
                 yield put(actions.setNetworkStatus(data.active));
                 console.log(`User has a network connection: ${data.active}`);
             } else if (event === "ready") {
+                yield call(setLastSyncedDate);
                 yield put(actions.setReadyStatus(true));
                 console.log("DataStore is ready");
+            } else if (event === "outboxStatus") {
+                const { isEmpty } = data;
+                if (!isEmpty) {
+                    console.log(
+                        "outbox is not empty, clearing last synced date"
+                    );
+                    yield call(clearLastSyncedDate);
+                } else {
+                    console.log("outbox is empty, setting last synced date");
+                    yield call(setLastSyncedDate);
+                }
             } else if (event === "modelSynced") {
                 console.log(`${data.model.name} is synced`);
                 yield put(actions.setModelSyncedStatus(data.model.name));

--- a/src/scenes/TenantPicker/TenantListProvider.tsx
+++ b/src/scenes/TenantPicker/TenantListProvider.tsx
@@ -4,6 +4,7 @@ import configureAmplify from "./utilities/configureAmplify";
 import saveAmplifyConfig from "../../utilities/saveAmplifyConfig";
 import TenantList from "./components/TenantList";
 import { Box, CircularProgress } from "@mui/material";
+import { DataStore } from "aws-amplify";
 
 type TenantListProviderProps = {
     children: React.ReactNode;
@@ -27,6 +28,15 @@ export const TenantListProvider: React.FC<TenantListProviderProps> = ({
     const setup = React.useCallback(async () => {
         if (offline) return;
         setIsProcessing(true);
+        const lastSynced = localStorage.getItem("dateLastSynced");
+        const sevenDaysAgo = new Date();
+        sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+        if (lastSynced && new Date(lastSynced) < sevenDaysAgo) {
+            console.log(
+                "more than 7 days since last sync, clearing stale data from DataStore"
+            );
+            await DataStore.clear();
+        }
         const tenantId = localStorage.getItem("tenantId");
         try {
             if (


### PR DESCRIPTION
Saves the last date that the outbox was cleared, or that DataStore fully synced.

On opening the app, TenantProvider clears data with DataStore.clear if it has been over a week, before presenting the rest of the app.