### PR TITLE
Changes to cognito and tenantId

### DIFF
--- a/amplify/backend/auth/platelet61a0ac07/override.ts
+++ b/amplify/backend/auth/platelet61a0ac07/override.ts
@@ -21,4 +21,8 @@ export function override(
         accessToken: "days",
         idToken: "days",
     };
+    resources.userPool.adminCreateUserConfig = {
+        ...resources.userPool.adminCreateUserConfig,
+        allowAdminCreateUserOnly: true,
+    };
 }

--- a/amplify/backend/auth/platelet61a0ac07/override.ts
+++ b/amplify/backend/auth/platelet61a0ac07/override.ts
@@ -1,0 +1,24 @@
+import {
+    AmplifyAuthCognitoStackTemplate,
+    AmplifyProjectInfo,
+} from "@aws-amplify/cli-extensibility-helper";
+
+export function override(
+    resources: AmplifyAuthCognitoStackTemplate,
+    amplifyProjectInfo: AmplifyProjectInfo
+) {
+    resources.userPoolClient.accessTokenValidity = 1;
+    resources.userPoolClient.idTokenValidity = 1;
+    resources.userPoolClientWeb.accessTokenValidity = 1;
+    resources.userPoolClientWeb.idTokenValidity = 1;
+    resources.userPoolClient.tokenValidityUnits = {
+        ...resources.userPoolClient.tokenValidityUnits,
+        accessToken: "days",
+        idToken: "days",
+    };
+    resources.userPoolClientWeb.tokenValidityUnits = {
+        ...resources.userPoolClient.tokenValidityUnits,
+        accessToken: "days",
+        idToken: "days",
+    };
+}

--- a/amplify/backend/function/plateletAddNewTenant/src/index.js
+++ b/amplify/backend/function/plateletAddNewTenant/src/index.js
@@ -274,10 +274,6 @@ async function updateUserTenantAndCognito(user, tenantId, cognitoId) {
                     Name: "email_verified",
                     Value: "true",
                 },
-                {
-                    Name: "custom:tenantId",
-                    Value: tenantId,
-                },
             ],
             UserPoolId: userPoolId,
             Username: user.username,

--- a/amplify/backend/function/plateletAddNewTenant/src/index.test.js
+++ b/amplify/backend/function/plateletAddNewTenant/src/index.test.js
@@ -260,10 +260,6 @@ describe("plateletAddNewTenant", () => {
                     Name: "email_verified",
                     Value: "true",
                 },
-                {
-                    Name: "custom:tenantId",
-                    Value: "testTenantId",
-                },
             ],
             UserPoolId: "testPoolId",
             Username: "testUsername",

--- a/amplify/backend/function/plateletAdminAddNewUser/src/index.js
+++ b/amplify/backend/function/plateletAdminAddNewUser/src/index.js
@@ -108,10 +108,6 @@ async function createNewCognitoUser(newUser, tenantId) {
                     Name: "email_verified",
                     Value: "true",
                 },
-                {
-                    Name: "custom:tenantId",
-                    Value: tenantId,
-                },
             ],
             TemporaryPassword: generatedPassword,
             UserPoolId: userPoolId,

--- a/amplify/backend/function/plateletAdminAddNewUser/src/index.test.js
+++ b/amplify/backend/function/plateletAdminAddNewUser/src/index.test.js
@@ -225,10 +225,6 @@ describe("plateletAdminAddNewUser", () => {
                     Name: "email_verified",
                     Value: "true",
                 },
-                {
-                    Name: "custom:tenantId",
-                    Value: mockEvent.arguments.tenantId,
-                },
             ],
             UserPoolId: "testPoolId",
             TemporaryPassword: expect.stringMatching(/^[\w+]{8}$/),
@@ -298,10 +294,6 @@ describe("plateletAdminAddNewUser", () => {
                 {
                     Name: "email_verified",
                     Value: "true",
-                },
-                {
-                    Name: "custom:tenantId",
-                    Value: mockEvent.arguments.tenantId,
                 },
             ],
             TemporaryPassword: expect.stringMatching(/^[\w+]{8}$/),

--- a/amplify/backend/function/plateletProfilePictureUploadURLResolver/src/index.js
+++ b/amplify/backend/function/plateletProfilePictureUploadURLResolver/src/index.js
@@ -89,17 +89,10 @@ exports.handler = async (event) => {
     console.log("user:", user);
     if (!user) return new Promise((_, reject) => reject("User not found"));
     if (event.identity.claims["cognito:groups"].includes("ADMIN")) {
-        let tenantId = event.identity.claims["custom:tenantId"];
-        // for some reason this isn't always defined
-        // get it from the API if it isn't
-        if (!tenantId) {
-            const adminResult = await getUserByCognitoId(
-                event.identity.claims.sub
-            );
-            const admin = adminResult.data.getUserByCognitoId.items[0];
-            console.log("admin:", admin);
-            tenantId = admin.tenantId;
-        }
+        const adminResult = await getUserByCognitoId(event.identity.claims.sub);
+        const admin = adminResult.data.getUserByCognitoId.items[0];
+        console.log("admin:", admin);
+        const tenantId = admin.tenantId;
         if (user.tenantId === tenantId) {
             return generatePresignedUrl(`public/${event.arguments.userId}.jpg`);
         } else {

--- a/src/redux/whoami/__snapshots__/whoamiSagas.test.js.snap
+++ b/src/redux/whoami/__snapshots__/whoamiSagas.test.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`whoamiSagas API failure 1`] = `
+Array [
+  Object {
+    "error": [Error: someError],
+    "type": "GET_WHOAMI_FAILURE",
+  },
+]
+`;
+
+exports[`whoamiSagas can't find the user 1`] = `
+Array [
+  Object {
+    "error": [NotFoundError: Could not find tenant id for user],
+    "type": "GET_WHOAMI_FAILURE",
+  },
+]
+`;
+
+exports[`whoamiSagas demo mode 1`] = `
+Array [
+  Object {
+    "data": "offline",
+    "type": "SET_TENANT_ID",
+  },
+]
+`;
+
+exports[`whoamiSagas get the user data from DataStore and the tenantId from localstorage 1`] = `
+Array [
+  Object {
+    "data": "someTenantId",
+    "type": "SET_TENANT_ID",
+  },
+]
+`;
+
+exports[`whoamiSagas get the user data from the API and save the tenantId 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "cognitoId": "someCognitoId",
+      "id": "someUserId",
+      "tenantId": "someTenantId",
+    },
+    "type": "GET_WHOAMI_SUCCESS",
+  },
+  Object {
+    "type": "INIT_WHOAMI_OBSERVER",
+    "whoamiId": "someUserId",
+  },
+  Object {
+    "data": "someTenantId",
+    "type": "SET_TENANT_ID",
+  },
+]
+`;

--- a/src/redux/whoami/whoamiSagas.test.js
+++ b/src/redux/whoami/whoamiSagas.test.js
@@ -1,0 +1,199 @@
+import { API, Auth, DataStore } from "aws-amplify";
+import { testFunctions } from "./whoamiSagas";
+import { runSaga } from "redux-saga";
+import * as awsAmplify from "aws-amplify";
+import * as models from "../../models";
+import * as whoamiActions from "./whoamiActions";
+
+const fakeUser = {
+    cognitoId: "someCognitoId",
+    tenantId: "someTenantId",
+    id: "someUserId",
+};
+
+const fakeCognitoResponse = {
+    attributes: {
+        sub: "someCognitoId",
+    },
+};
+
+jest.mock("uuid", () => ({ v4: () => "someUUID" }));
+
+describe("whoamiSagas", () => {
+    beforeEach(() => {
+        process.env.REACT_APP_DEMO_MODE = "false";
+        process.env.REACT_APP_OFFLINE_ONLY = "false";
+    });
+    afterEach(async () => {
+        jest.restoreAllMocks();
+        await DataStore.clear();
+    });
+    it("get the user data from the API and save the tenantId", async () => {
+        const dispatched = [];
+        jest.spyOn(Auth, "currentAuthenticatedUser").mockResolvedValue(
+            fakeCognitoResponse
+        );
+        jest.spyOn(API, "graphql").mockResolvedValue({
+            data: { getUserByCognitoId: { items: [fakeUser] } },
+        });
+        jest.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
+        const setSpy = jest.spyOn(Storage.prototype, "setItem");
+        const syncExpressionSpy = jest.spyOn(awsAmplify, "syncExpression");
+
+        await runSaga(
+            {
+                dispatch: (action) => dispatched.push(action),
+                getState: () => ({ state: "test" }),
+            },
+            testFunctions.getWhoami
+        ).toPromise();
+
+        expect(dispatched).toMatchSnapshot();
+        expect(setSpy).toHaveBeenCalledWith("userTenantId", "someTenantId");
+        for (const m of Object.values(models)) {
+            if (!m.hasOwnProperty("copyOf")) continue;
+            expect(syncExpressionSpy).toHaveBeenCalledWith(
+                m,
+                expect.any(Function)
+            );
+        }
+    });
+    it("get the user data from DataStore and the tenantId from localstorage", async () => {
+        const dispatched = [];
+        const mockWhoami = await DataStore.save(
+            new models.User({
+                displayName: "test",
+                tenantId: "someTenant",
+                cognitoId: "someCognitoId",
+            })
+        );
+        jest.spyOn(Auth, "currentAuthenticatedUser").mockResolvedValue(
+            fakeCognitoResponse
+        );
+        jest.spyOn(API, "graphql").mockResolvedValue({
+            data: { getUserByCognitoId: { items: [fakeUser] } },
+        });
+        jest.spyOn(Storage.prototype, "getItem").mockReturnValue(
+            "someTenantId"
+        );
+
+        const apiSpy = jest.spyOn(API, "graphql").mockResolvedValue({});
+        const setSpy = jest.spyOn(Storage.prototype, "setItem");
+        const syncExpressionSpy = jest.spyOn(awsAmplify, "syncExpression");
+
+        await runSaga(
+            {
+                dispatch: (action) => dispatched.push(action),
+                getState: () => ({ state: "test" }),
+            },
+            testFunctions.getWhoami
+        ).toPromise();
+
+        const successAction = dispatched.find(
+            (a) => a.type === whoamiActions.GET_WHOAMI_SUCCESS
+        );
+        expect(successAction.data).toEqual(mockWhoami);
+        const initWhoamiObserverAction = dispatched.find(
+            (a) => a.type === whoamiActions.INIT_WHOAMI_OBSERVER
+        );
+        expect(initWhoamiObserverAction).toEqual({
+            type: whoamiActions.INIT_WHOAMI_OBSERVER,
+            whoamiId: mockWhoami.id,
+        });
+        const filteredDispatched = dispatched.filter(
+            (a) =>
+                a.type !== whoamiActions.GET_WHOAMI_SUCCESS &&
+                a.type !== whoamiActions.INIT_WHOAMI_OBSERVER
+        );
+        expect(filteredDispatched).toMatchSnapshot();
+        expect(apiSpy).not.toHaveBeenCalled();
+        expect(setSpy).not.toHaveBeenCalled();
+        for (const m of Object.values(models)) {
+            if (!m.hasOwnProperty("copyOf")) continue;
+            expect(syncExpressionSpy).toHaveBeenCalledWith(
+                m,
+                expect.any(Function)
+            );
+        }
+    });
+    it("demo mode", async () => {
+        process.env.REACT_APP_DEMO_MODE = "true";
+        const dispatched = [];
+        const mockWhoami = await DataStore.save(
+            new models.User({
+                displayName: "test",
+                name: "offline",
+                tenantId: "someTenant",
+                cognitoId: "someCognitoId",
+            })
+        );
+        await runSaga(
+            {
+                dispatch: (action) => dispatched.push(action),
+                getState: () => ({ state: "test" }),
+            },
+            testFunctions.getWhoami
+        ).toPromise();
+        const successAction = dispatched.find(
+            (a) => a.type === whoamiActions.GET_WHOAMI_SUCCESS
+        );
+        expect(successAction.data).toEqual(mockWhoami);
+        const initWhoamiObserverAction = dispatched.find(
+            (a) => a.type === whoamiActions.INIT_WHOAMI_OBSERVER
+        );
+        expect(initWhoamiObserverAction).toEqual({
+            type: whoamiActions.INIT_WHOAMI_OBSERVER,
+            whoamiId: mockWhoami.id,
+        });
+        const filteredDispatched = dispatched.filter(
+            (a) =>
+                a.type !== whoamiActions.GET_WHOAMI_SUCCESS &&
+                a.type !== whoamiActions.INIT_WHOAMI_OBSERVER
+        );
+        expect(filteredDispatched).toMatchSnapshot();
+    });
+    it("API failure", async () => {
+        const dispatched = [];
+        jest.spyOn(Auth, "currentAuthenticatedUser").mockResolvedValue(
+            fakeCognitoResponse
+        );
+        const removeSpy = jest.spyOn(Storage.prototype, "removeItem");
+        jest.spyOn(API, "graphql").mockRejectedValue(new Error("someError"));
+        jest.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
+        const setSpy = jest.spyOn(Storage.prototype, "setItem");
+
+        await runSaga(
+            {
+                dispatch: (action) => dispatched.push(action),
+                getState: () => ({ state: "test" }),
+            },
+            testFunctions.getWhoami
+        ).toPromise();
+
+        expect(dispatched).toMatchSnapshot();
+        expect(setSpy).not.toHaveBeenCalled();
+        expect(removeSpy).toHaveBeenCalledWith("userTenantId");
+    });
+    it("can't find the user", async () => {
+        const dispatched = [];
+        jest.spyOn(Auth, "currentAuthenticatedUser").mockResolvedValue(
+            fakeCognitoResponse
+        );
+        jest.spyOn(API, "graphql").mockResolvedValue({
+            data: { getUserByCognitoId: { items: [] } },
+        });
+        jest.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
+        const removeSpy = jest.spyOn(Storage.prototype, "removeItem");
+
+        await runSaga(
+            {
+                dispatch: (action) => dispatched.push(action),
+                getState: () => ({ state: "test" }),
+            },
+            testFunctions.getWhoami
+        ).toPromise();
+
+        expect(dispatched).toMatchSnapshot();
+        expect(removeSpy).toHaveBeenCalledWith("userTenantId");
+    });
+});


### PR DESCRIPTION
Removes the reliance on the custom:tenantId attribute from cognito.

whoami saga now gets tenantId data from localstorage or from the API.

Some tests for whoami saga.

New deployments now have these values set to one day for both web and mobile clients:

accessTokenValidity
idTokenValidity

This helps with not logging out users if they don't have an internet connection.

Self sign up is now disabled by default on new deployments.