### PR TITLE
feat/226: clear datastore in Login.tsx if no logged in user is found

### DIFF
--- a/src/navigation/Components/LightToggleProfileMenu.test.js
+++ b/src/navigation/Components/LightToggleProfileMenu.test.js
@@ -29,8 +29,6 @@ describe("LightToggleProfileMenu", () => {
         render(<LightToggleProfileMenu />, { preloadedState });
         userEvent.click(screen.getByText("TU"));
         userEvent.click(screen.getByText("Logout"));
-        await waitFor(() => expect(amplify.DataStore.stop).toHaveBeenCalled());
-        await waitFor(() => expect(amplify.DataStore.clear).toHaveBeenCalled());
         await waitFor(() => expect(amplify.Auth.signOut).toHaveBeenCalled());
     });
     it("links to the user's profile", () => {

--- a/src/redux/login/LoginSagas.js
+++ b/src/redux/login/LoginSagas.js
@@ -12,7 +12,7 @@ import {
 import { getApiControl } from "../Selectors";
 import { saveLogin } from "../../utilities";
 import { displayWarningNotification } from "../notifications/NotificationsActions";
-import { Auth, DataStore } from "aws-amplify";
+import { Auth } from "aws-amplify";
 import { GET_WHOAMI_FAILURE } from "../whoami/whoamiActions";
 
 function* login(action) {
@@ -52,13 +52,10 @@ function* logout(action) {
             yield call([channel, channel.postMessage], "logout");
         }
         yield call([localStorage, localStorage.removeItem], "userTenantId");
-        yield call([DataStore, DataStore.stop]);
-        yield call([DataStore, DataStore.clear]);
     } catch (error) {
         console.log(error);
     } finally {
-        // if DataStore fails to clear for some reason
-        // we still want to logout the user
+        // always log out and refresh
         yield call([Auth, Auth.signOut]);
         yield call([window, window.location.reload.bind(window.location)]);
     }

--- a/src/scenes/Login/Login.tsx
+++ b/src/scenes/Login/Login.tsx
@@ -46,7 +46,6 @@ const Login: React.FC<LoginProps> = ({ children }) => {
         if (!clearingData) return;
         const user = await Auth.currentAuthenticatedUser().catch(() => null);
         if (!user) {
-            setClearingData(true);
             console.log("Clearing DataStore");
             await DataStore.stop();
             await DataStore.clear();


### PR DESCRIPTION
Removes the datastore.clear functionality from the logout saga and instead does it in Login.tsx when no user is found to be logged in.