### PR TITLE
feat/270: register tenant via lambda function instead of query

### DIFF
--- a/cdk/lib/cypress-test-role-construct.ts
+++ b/cdk/lib/cypress-test-role-construct.ts
@@ -29,9 +29,7 @@ export class CypressTestRole extends Construct {
             { graphqlApiId: props.appsyncId }
         );
 
-        this.role = new iam.Role(this, "Role", {
-            description:
-                "Assumed by Cypress E2E tests to set isBeingDeleted on User records via AppSync IAM auth.",
+        this.role = new iam.Role(this, "CypressRole", {
             assumedBy: new iam.AccountPrincipal(cdk.Stack.of(this).account),
         });
 

--- a/cdk/lib/lambda/node/RegisterTenant/babel.config.cjs
+++ b/cdk/lib/lambda/node/RegisterTenant/babel.config.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+    presets: [
+        [
+            "@babel/preset-env",
+            {
+                targets: {
+                    esmodules: true,
+                },
+            },
+        ],
+        "@babel/preset-typescript",
+    ],
+};

--- a/cdk/lib/lambda/node/RegisterTenant/jest.config.js
+++ b/cdk/lib/lambda/node/RegisterTenant/jest.config.js
@@ -1,0 +1,21 @@
+import { createDefaultPreset } from "ts-jest";
+
+const tsJestTransformCfg = createDefaultPreset().transform;
+
+/** @type {import("jest").Config} **/
+export default {
+    setupFiles: ["<rootDir>/setupTests.ts"],
+    testEnvironment: "node",
+    extensionsToTreatAsEsm: [".ts"],
+    moduleNameMapper: {
+        "^(\\.\\.?\\/.+)\\.js$": "$1",
+    },
+    globals: {
+        "ts-jest": {
+            useESM: true,
+        },
+    },
+    transform: {
+        ...tsJestTransformCfg,
+    },
+};

--- a/cdk/lib/lambda/node/RegisterTenant/package-lock.json
+++ b/cdk/lib/lambda/node/RegisterTenant/package-lock.json
@@ -17,6 +17,7 @@
             },
             "devDependencies": {
                 "@types/jest": "^30.0.0",
+                "aws-sdk-client-mock": "^4.1.0",
                 "jest": "^30.2.0",
                 "ts-jest": "^29.4.5"
             }
@@ -3112,6 +3113,27 @@
                 "@sinonjs/commons": "^3.0.1"
             }
         },
+        "node_modules/@sinonjs/samsam": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+            "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1",
+                "type-detect": "^4.1.0"
+            }
+        },
+        "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+            "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/@smithy/config-resolver": {
             "version": "4.4.4",
             "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.4.tgz",
@@ -3747,6 +3769,23 @@
                 "form-data": "^4.0.4"
             }
         },
+        "node_modules/@types/sinon": {
+            "version": "17.0.4",
+            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+            "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/sinonjs__fake-timers": "*"
+            }
+        },
+        "node_modules/@types/sinonjs__fake-timers": {
+            "version": "15.0.1",
+            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+            "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -4121,6 +4160,18 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "license": "MIT"
+        },
+        "node_modules/aws-sdk-client-mock": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
+            "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/sinon": "^17.0.3",
+                "sinon": "^18.0.1",
+                "tslib": "^2.1.0"
+            }
         },
         "node_modules/babel-jest": {
             "version": "30.2.0",
@@ -4652,6 +4703,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/diff": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
             }
         },
         "node_modules/dunder-proto": {
@@ -6050,6 +6111,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/just-extend": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+            "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/leven": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -6277,6 +6345,29 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/nise": {
+            "version": "6.1.5",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.5.tgz",
+            "integrity": "sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1",
+                "@sinonjs/fake-timers": "^15.1.1",
+                "just-extend": "^6.2.0",
+                "path-to-regexp": "^8.3.0"
+            }
+        },
+        "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+            "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1"
+            }
+        },
         "node_modules/node-fetch": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -6495,6 +6586,17 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/path-to-regexp": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6667,6 +6769,35 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/sinon": {
+            "version": "18.0.1",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+            "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1",
+                "@sinonjs/fake-timers": "11.2.2",
+                "@sinonjs/samsam": "^8.0.0",
+                "diff": "^5.2.0",
+                "nise": "^6.0.0",
+                "supports-color": "^7"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/sinon"
+            }
+        },
+        "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
+            "version": "11.2.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+            "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.0"
             }
         },
         "node_modules/slash": {

--- a/cdk/lib/lambda/node/RegisterTenant/package-lock.json
+++ b/cdk/lib/lambda/node/RegisterTenant/package-lock.json
@@ -9,7 +9,8 @@
             "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-cognito-identity-provider": "^3.908.0"
+                "@aws-sdk/client-cognito-identity-provider": "^3.908.0",
+                "uuid": "^14.0.1"
             },
             "devDependencies": {
                 "@types/jest": "^30.0.0",
@@ -5731,6 +5732,19 @@
             },
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+            "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist-node/bin/uuid"
             }
         },
         "node_modules/v8-to-istanbul": {

--- a/cdk/lib/lambda/node/RegisterTenant/package-lock.json
+++ b/cdk/lib/lambda/node/RegisterTenant/package-lock.json
@@ -1,0 +1,6023 @@
+{
+    "name": "register-tenant",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "register-tenant",
+            "version": "1.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-cognito-identity-provider": "^3.908.0"
+            },
+            "devDependencies": {
+                "@types/jest": "^30.0.0",
+                "jest": "^30.2.0",
+                "ts-jest": "^29.4.5"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity-provider": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.908.0.tgz",
+            "integrity": "sha512-mdNMZTiFO5pyG1EmiBMoiLPMYVg1wSh1MtQu33FiA97L/jbQBQZucb2Wdz2YSl9FkiYNV9wrBSZ7v5S+UpNDUA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.908.0",
+                "@aws-sdk/credential-provider-node": "3.908.0",
+                "@aws-sdk/middleware-host-header": "3.901.0",
+                "@aws-sdk/middleware-logger": "3.901.0",
+                "@aws-sdk/middleware-recursion-detection": "3.901.0",
+                "@aws-sdk/middleware-user-agent": "3.908.0",
+                "@aws-sdk/region-config-resolver": "3.901.0",
+                "@aws-sdk/types": "3.901.0",
+                "@aws-sdk/util-endpoints": "3.901.0",
+                "@aws-sdk/util-user-agent-browser": "3.907.0",
+                "@aws-sdk/util-user-agent-node": "3.908.0",
+                "@smithy/config-resolver": "^4.3.0",
+                "@smithy/core": "^3.15.0",
+                "@smithy/fetch-http-handler": "^5.3.1",
+                "@smithy/hash-node": "^4.2.0",
+                "@smithy/invalid-dependency": "^4.2.0",
+                "@smithy/middleware-content-length": "^4.2.0",
+                "@smithy/middleware-endpoint": "^4.3.1",
+                "@smithy/middleware-retry": "^4.4.1",
+                "@smithy/middleware-serde": "^4.2.0",
+                "@smithy/middleware-stack": "^4.2.0",
+                "@smithy/node-config-provider": "^4.3.0",
+                "@smithy/node-http-handler": "^4.3.0",
+                "@smithy/protocol-http": "^5.3.0",
+                "@smithy/smithy-client": "^4.7.1",
+                "@smithy/types": "^4.6.0",
+                "@smithy/url-parser": "^4.2.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.0",
+                "@smithy/util-defaults-mode-node": "^4.2.1",
+                "@smithy/util-endpoints": "^3.2.0",
+                "@smithy/util-middleware": "^4.2.0",
+                "@smithy/util-retry": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.908.0.tgz",
+            "integrity": "sha512-PseFMWvtac+Q+zaY9DMISE+2+glNh0ROJ1yR4gMzeafNHSwkdYu4qcgxLWIOnIodGydBv/tQ6nzHPzExXnUUgw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.908.0",
+                "@aws-sdk/middleware-host-header": "3.901.0",
+                "@aws-sdk/middleware-logger": "3.901.0",
+                "@aws-sdk/middleware-recursion-detection": "3.901.0",
+                "@aws-sdk/middleware-user-agent": "3.908.0",
+                "@aws-sdk/region-config-resolver": "3.901.0",
+                "@aws-sdk/types": "3.901.0",
+                "@aws-sdk/util-endpoints": "3.901.0",
+                "@aws-sdk/util-user-agent-browser": "3.907.0",
+                "@aws-sdk/util-user-agent-node": "3.908.0",
+                "@smithy/config-resolver": "^4.3.0",
+                "@smithy/core": "^3.15.0",
+                "@smithy/fetch-http-handler": "^5.3.1",
+                "@smithy/hash-node": "^4.2.0",
+                "@smithy/invalid-dependency": "^4.2.0",
+                "@smithy/middleware-content-length": "^4.2.0",
+                "@smithy/middleware-endpoint": "^4.3.1",
+                "@smithy/middleware-retry": "^4.4.1",
+                "@smithy/middleware-serde": "^4.2.0",
+                "@smithy/middleware-stack": "^4.2.0",
+                "@smithy/node-config-provider": "^4.3.0",
+                "@smithy/node-http-handler": "^4.3.0",
+                "@smithy/protocol-http": "^5.3.0",
+                "@smithy/smithy-client": "^4.7.1",
+                "@smithy/types": "^4.6.0",
+                "@smithy/url-parser": "^4.2.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.0",
+                "@smithy/util-defaults-mode-node": "^4.2.1",
+                "@smithy/util-endpoints": "^3.2.0",
+                "@smithy/util-middleware": "^4.2.0",
+                "@smithy/util-retry": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.908.0.tgz",
+            "integrity": "sha512-okl6FC2cQT1Oidvmnmvyp/IEvqENBagKO0ww4YV5UtBkf0VlhAymCWkZqhovtklsqgq0otag2VRPAgnrMt6nVQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.901.0",
+                "@aws-sdk/xml-builder": "3.901.0",
+                "@smithy/core": "^3.15.0",
+                "@smithy/node-config-provider": "^4.3.0",
+                "@smithy/property-provider": "^4.2.0",
+                "@smithy/protocol-http": "^5.3.0",
+                "@smithy/signature-v4": "^5.3.0",
+                "@smithy/smithy-client": "^4.7.1",
+                "@smithy/types": "^4.6.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.908.0.tgz",
+            "integrity": "sha512-FK2YuxoI5CxUflPOIMbVAwDbi6Xvu+2sXopXLmrHc2PfI39M3vmjEoQwYCP8WuQSRb+TbAP3xAkxHjFSBFR35w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.908.0",
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/property-provider": "^4.2.0",
+                "@smithy/types": "^4.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.908.0.tgz",
+            "integrity": "sha512-eLbz0geVW9EykujQNnYfR35Of8MreI6pau5K6XDFDUSWO9GF8wqH7CQwbXpXHBlCTHtq4QSLxzorD8U5CROhUw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.908.0",
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/fetch-http-handler": "^5.3.1",
+                "@smithy/node-http-handler": "^4.3.0",
+                "@smithy/property-provider": "^4.2.0",
+                "@smithy/protocol-http": "^5.3.0",
+                "@smithy/smithy-client": "^4.7.1",
+                "@smithy/types": "^4.6.0",
+                "@smithy/util-stream": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.908.0.tgz",
+            "integrity": "sha512-7Cgnv5wabgFtsgr+Uc/76EfPNGyxmbG8aICn3g3D3iJlcO4uuOZI8a77i0afoDdchZrTC6TG6UusS/NAW6zEoQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.908.0",
+                "@aws-sdk/credential-provider-env": "3.908.0",
+                "@aws-sdk/credential-provider-http": "3.908.0",
+                "@aws-sdk/credential-provider-process": "3.908.0",
+                "@aws-sdk/credential-provider-sso": "3.908.0",
+                "@aws-sdk/credential-provider-web-identity": "3.908.0",
+                "@aws-sdk/nested-clients": "3.908.0",
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/credential-provider-imds": "^4.2.0",
+                "@smithy/property-provider": "^4.2.0",
+                "@smithy/shared-ini-file-loader": "^4.3.0",
+                "@smithy/types": "^4.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.908.0.tgz",
+            "integrity": "sha512-8OKbykpGw5bdfF/pLTf8YfUi1Kl8o1CTjBqWQTsLOkE3Ho3hsp1eQx8Cz4ttrpv0919kb+lox62DgmAOEmTr1w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.908.0",
+                "@aws-sdk/credential-provider-http": "3.908.0",
+                "@aws-sdk/credential-provider-ini": "3.908.0",
+                "@aws-sdk/credential-provider-process": "3.908.0",
+                "@aws-sdk/credential-provider-sso": "3.908.0",
+                "@aws-sdk/credential-provider-web-identity": "3.908.0",
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/credential-provider-imds": "^4.2.0",
+                "@smithy/property-provider": "^4.2.0",
+                "@smithy/shared-ini-file-loader": "^4.3.0",
+                "@smithy/types": "^4.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.908.0.tgz",
+            "integrity": "sha512-sWnbkGjDPBi6sODUzrAh5BCDpnPw0wpK8UC/hWI13Q8KGfyatAmCBfr+9OeO3+xBHa8N5AskMncr7C4qS846yQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.908.0",
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/property-provider": "^4.2.0",
+                "@smithy/shared-ini-file-loader": "^4.3.0",
+                "@smithy/types": "^4.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.908.0.tgz",
+            "integrity": "sha512-WV/aOzuS6ZZhrkPty6TJ3ZG24iS8NXP0m3GuTVuZ5tKi9Guss31/PJ1CrKPRCYGm15CsIjf+mrUxVnNYv9ap5g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.908.0",
+                "@aws-sdk/core": "3.908.0",
+                "@aws-sdk/token-providers": "3.908.0",
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/property-provider": "^4.2.0",
+                "@smithy/shared-ini-file-loader": "^4.3.0",
+                "@smithy/types": "^4.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.908.0.tgz",
+            "integrity": "sha512-9xWrFn6nWlF5KlV4XYW+7E6F33S3wUUEGRZ/+pgDhkIZd527ycT2nPG2dZ3fWUZMlRmzijP20QIJDqEbbGWe1Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.908.0",
+                "@aws-sdk/nested-clients": "3.908.0",
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/property-provider": "^4.2.0",
+                "@smithy/shared-ini-file-loader": "^4.3.0",
+                "@smithy/types": "^4.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.901.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.901.0.tgz",
+            "integrity": "sha512-yWX7GvRmqBtbNnUW7qbre3GvZmyYwU0WHefpZzDTYDoNgatuYq6LgUIQ+z5C04/kCRoFkAFrHag8a3BXqFzq5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/protocol-http": "^5.3.0",
+                "@smithy/types": "^4.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.901.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.901.0.tgz",
+            "integrity": "sha512-UoHebjE7el/tfRo8/CQTj91oNUm+5Heus5/a4ECdmWaSCHCS/hXTsU3PTTHAY67oAQR8wBLFPfp3mMvXjB+L2A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/types": "^4.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.901.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.901.0.tgz",
+            "integrity": "sha512-Wd2t8qa/4OL0v/oDpCHHYkgsXJr8/ttCxrvCKAt0H1zZe2LlRhY9gpDVKqdertfHrHDj786fOvEQA28G1L75Dg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.901.0",
+                "@aws/lambda-invoke-store": "^0.0.1",
+                "@smithy/protocol-http": "^5.3.0",
+                "@smithy/types": "^4.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.908.0.tgz",
+            "integrity": "sha512-R0ePEOku72EvyJWy/D0Z5f/Ifpfxa0U9gySO3stpNhOox87XhsILpcIsCHPy0OHz1a7cMoZsF6rMKSzDeCnogQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.908.0",
+                "@aws-sdk/types": "3.901.0",
+                "@aws-sdk/util-endpoints": "3.901.0",
+                "@smithy/core": "^3.15.0",
+                "@smithy/protocol-http": "^5.3.0",
+                "@smithy/types": "^4.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.908.0.tgz",
+            "integrity": "sha512-ZxDYrfxOKXNFHLyvJtT96TJ0p4brZOhwRE4csRXrezEVUN+pNgxuem95YvMALPVhlVqON2CTzr8BX+CcBKvX9Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.908.0",
+                "@aws-sdk/middleware-host-header": "3.901.0",
+                "@aws-sdk/middleware-logger": "3.901.0",
+                "@aws-sdk/middleware-recursion-detection": "3.901.0",
+                "@aws-sdk/middleware-user-agent": "3.908.0",
+                "@aws-sdk/region-config-resolver": "3.901.0",
+                "@aws-sdk/types": "3.901.0",
+                "@aws-sdk/util-endpoints": "3.901.0",
+                "@aws-sdk/util-user-agent-browser": "3.907.0",
+                "@aws-sdk/util-user-agent-node": "3.908.0",
+                "@smithy/config-resolver": "^4.3.0",
+                "@smithy/core": "^3.15.0",
+                "@smithy/fetch-http-handler": "^5.3.1",
+                "@smithy/hash-node": "^4.2.0",
+                "@smithy/invalid-dependency": "^4.2.0",
+                "@smithy/middleware-content-length": "^4.2.0",
+                "@smithy/middleware-endpoint": "^4.3.1",
+                "@smithy/middleware-retry": "^4.4.1",
+                "@smithy/middleware-serde": "^4.2.0",
+                "@smithy/middleware-stack": "^4.2.0",
+                "@smithy/node-config-provider": "^4.3.0",
+                "@smithy/node-http-handler": "^4.3.0",
+                "@smithy/protocol-http": "^5.3.0",
+                "@smithy/smithy-client": "^4.7.1",
+                "@smithy/types": "^4.6.0",
+                "@smithy/url-parser": "^4.2.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.0",
+                "@smithy/util-defaults-mode-node": "^4.2.1",
+                "@smithy/util-endpoints": "^3.2.0",
+                "@smithy/util-middleware": "^4.2.0",
+                "@smithy/util-retry": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.901.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.901.0.tgz",
+            "integrity": "sha512-7F0N888qVLHo4CSQOsnkZ4QAp8uHLKJ4v3u09Ly5k4AEStrSlFpckTPyUx6elwGL+fxGjNE2aakK8vEgzzCV0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/node-config-provider": "^4.3.0",
+                "@smithy/types": "^4.6.0",
+                "@smithy/util-config-provider": "^4.2.0",
+                "@smithy/util-middleware": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.908.0.tgz",
+            "integrity": "sha512-4SosHWRQ8hj1X2yDenCYHParcCjHcd7S+Mdb/lelwF0JBFCNC+dNCI9ws3cP/dFdZO/AIhJQGUBzEQtieloixw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.908.0",
+                "@aws-sdk/nested-clients": "3.908.0",
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/property-provider": "^4.2.0",
+                "@smithy/shared-ini-file-loader": "^4.3.0",
+                "@smithy/types": "^4.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.901.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.901.0.tgz",
+            "integrity": "sha512-FfEM25hLEs4LoXsLXQ/q6X6L4JmKkKkbVFpKD4mwfVHtRVQG6QxJiCPcrkcPISquiy6esbwK2eh64TWbiD60cg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.901.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.901.0.tgz",
+            "integrity": "sha512-5nZP3hGA8FHEtKvEQf4Aww5QZOkjLW1Z+NixSd+0XKfHvA39Ah5sZboScjLx0C9kti/K3OGW1RCx5K9Zc3bZqg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/types": "^4.6.0",
+                "@smithy/url-parser": "^4.2.0",
+                "@smithy/util-endpoints": "^3.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.893.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.893.0.tgz",
+            "integrity": "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.907.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.907.0.tgz",
+            "integrity": "sha512-Hus/2YCQmtCEfr4Ls88d07Q99Ex59uvtktiPTV963Q7w7LHuIT/JBjrbwNxtSm2KlJR9PHNdqxwN+fSuNsMGMQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/types": "^4.6.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.908.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.908.0.tgz",
+            "integrity": "sha512-l6AEaKUAYarcEy8T8NZ+dNZ00VGLs3fW2Cqu1AuPENaSad0/ahEU+VU7MpXS8FhMRGPgplxKVgCTLyTY0Lbssw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.908.0",
+                "@aws-sdk/types": "3.901.0",
+                "@smithy/node-config-provider": "^4.3.0",
+                "@smithy/types": "^4.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/xml-builder": {
+            "version": "3.901.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.901.0.tgz",
+            "integrity": "sha512-pxFCkuAP7Q94wMTNPAwi6hEtNrp/BdFf+HOrIEeFQsk4EoOmpKY3I6S+u6A9Wg295J80Kh74LqDWM22ux3z6Aw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.6.0",
+                "fast-xml-parser": "5.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws/lambda-invoke-store": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.0.1.tgz",
+            "integrity": "sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/compat-data": {
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+            "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core": {
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+            "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.28.3",
+                "@babel/helper-compilation-targets": "^7.27.2",
+                "@babel/helper-module-transforms": "^7.28.3",
+                "@babel/helpers": "^7.28.4",
+                "@babel/parser": "^7.28.4",
+                "@babel/template": "^7.27.2",
+                "@babel/traverse": "^7.28.4",
+                "@babel/types": "^7.28.4",
+                "@jridgewell/remapping": "^2.3.5",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/generator": {
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+            "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.28.3",
+                "@babel/types": "^7.28.2",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets": {
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+            "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.27.2",
+                "@babel/helper-validator-option": "^7.27.1",
+                "browserslist": "^4.24.0",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms": {
+            "version": "7.28.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+            "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/traverse": "^7.28.3"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-plugin-utils": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+            "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-option": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers": {
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+            "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.28.4"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+            "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.4"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-async-generators": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-bigint": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+            "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-class-properties": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+            "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.12.13"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-class-static-block": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+            "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.14.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-import-attributes": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+            "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-import-meta": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+            "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-json-strings": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-jsx": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+            "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-numeric-separator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-optional-chaining": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-private-property-in-object": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+            "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.14.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-top-level-await": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+            "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.14.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-typescript": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+            "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@babel/parser": "^7.27.2",
+                "@babel/types": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+            "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.28.3",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.28.4",
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.28.4",
+                "debug": "^4.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+            "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@bcoe/v8-coverage": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+            "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.3",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+            "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+            "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "camelcase": "^5.3.1",
+                "find-up": "^4.1.0",
+                "get-package-type": "^0.1.0",
+                "js-yaml": "^3.13.1",
+                "resolve-from": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/schema": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@jest/console": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.2.0.tgz",
+            "integrity": "sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.2.0",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "jest-message-util": "30.2.0",
+                "jest-util": "30.2.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/core": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.2.0.tgz",
+            "integrity": "sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/console": "30.2.0",
+                "@jest/pattern": "30.0.1",
+                "@jest/reporters": "30.2.0",
+                "@jest/test-result": "30.2.0",
+                "@jest/transform": "30.2.0",
+                "@jest/types": "30.2.0",
+                "@types/node": "*",
+                "ansi-escapes": "^4.3.2",
+                "chalk": "^4.1.2",
+                "ci-info": "^4.2.0",
+                "exit-x": "^0.2.2",
+                "graceful-fs": "^4.2.11",
+                "jest-changed-files": "30.2.0",
+                "jest-config": "30.2.0",
+                "jest-haste-map": "30.2.0",
+                "jest-message-util": "30.2.0",
+                "jest-regex-util": "30.0.1",
+                "jest-resolve": "30.2.0",
+                "jest-resolve-dependencies": "30.2.0",
+                "jest-runner": "30.2.0",
+                "jest-runtime": "30.2.0",
+                "jest-snapshot": "30.2.0",
+                "jest-util": "30.2.0",
+                "jest-validate": "30.2.0",
+                "jest-watcher": "30.2.0",
+                "micromatch": "^4.0.8",
+                "pretty-format": "30.2.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@jest/diff-sequences": {
+            "version": "30.0.1",
+            "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+            "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/environment": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
+            "integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/fake-timers": "30.2.0",
+                "@jest/types": "30.2.0",
+                "@types/node": "*",
+                "jest-mock": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/expect": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.2.0.tgz",
+            "integrity": "sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "expect": "30.2.0",
+                "jest-snapshot": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/expect-utils": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
+            "integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/fake-timers": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
+            "integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.2.0",
+                "@sinonjs/fake-timers": "^13.0.0",
+                "@types/node": "*",
+                "jest-message-util": "30.2.0",
+                "jest-mock": "30.2.0",
+                "jest-util": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/get-type": {
+            "version": "30.1.0",
+            "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+            "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/globals": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
+            "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.2.0",
+                "@jest/expect": "30.2.0",
+                "@jest/types": "30.2.0",
+                "jest-mock": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/pattern": {
+            "version": "30.0.1",
+            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+            "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "jest-regex-util": "30.0.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/reporters": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.2.0.tgz",
+            "integrity": "sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@jest/console": "30.2.0",
+                "@jest/test-result": "30.2.0",
+                "@jest/transform": "30.2.0",
+                "@jest/types": "30.2.0",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "collect-v8-coverage": "^1.0.2",
+                "exit-x": "^0.2.2",
+                "glob": "^10.3.10",
+                "graceful-fs": "^4.2.11",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-instrument": "^6.0.0",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^5.0.0",
+                "istanbul-reports": "^3.1.3",
+                "jest-message-util": "30.2.0",
+                "jest-util": "30.2.0",
+                "jest-worker": "30.2.0",
+                "slash": "^3.0.0",
+                "string-length": "^4.0.2",
+                "v8-to-istanbul": "^9.0.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@jest/schemas": {
+            "version": "30.0.5",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+            "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sinclair/typebox": "^0.34.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/snapshot-utils": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.2.0.tgz",
+            "integrity": "sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.2.0",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "natural-compare": "^1.4.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/source-map": {
+            "version": "30.0.1",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+            "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "callsites": "^3.1.0",
+                "graceful-fs": "^4.2.11"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/test-result": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.2.0.tgz",
+            "integrity": "sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/console": "30.2.0",
+                "@jest/types": "30.2.0",
+                "@types/istanbul-lib-coverage": "^2.0.6",
+                "collect-v8-coverage": "^1.0.2"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/test-sequencer": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.2.0.tgz",
+            "integrity": "sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/test-result": "30.2.0",
+                "graceful-fs": "^4.2.11",
+                "jest-haste-map": "30.2.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/transform": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.2.0.tgz",
+            "integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.27.4",
+                "@jest/types": "30.2.0",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "babel-plugin-istanbul": "^7.0.1",
+                "chalk": "^4.1.2",
+                "convert-source-map": "^2.0.0",
+                "fast-json-stable-stringify": "^2.1.0",
+                "graceful-fs": "^4.2.11",
+                "jest-haste-map": "30.2.0",
+                "jest-regex-util": "30.0.1",
+                "jest-util": "30.2.0",
+                "micromatch": "^4.0.8",
+                "pirates": "^4.0.7",
+                "slash": "^3.0.0",
+                "write-file-atomic": "^5.0.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jest/types": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+            "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/pattern": "30.0.1",
+                "@jest/schemas": "30.0.5",
+                "@types/istanbul-lib-coverage": "^2.0.6",
+                "@types/istanbul-reports": "^3.0.4",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.33",
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.3",
+                "@emnapi/runtime": "^1.4.3",
+                "@tybys/wasm-util": "^0.10.0"
+            }
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@pkgr/core": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+            "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/pkgr"
+            }
+        },
+        "node_modules/@sinclair/typebox": {
+            "version": "0.34.41",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+            "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@sinonjs/commons": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+            "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "node_modules/@sinonjs/fake-timers": {
+            "version": "13.0.5",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+            "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.1"
+            }
+        },
+        "node_modules/@smithy/abort-controller": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
+            "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/config-resolver": {
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.4.tgz",
+            "integrity": "sha512-s3U5ChS21DwU54kMmZ0UJumoS5cg0+rGVZvN6f5Lp6EbAVi0ZyP+qDSHdewfmXKUgNK1j3z45JyzulkDukrjAA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.6",
+                "@smithy/types": "^4.10.0",
+                "@smithy/util-config-provider": "^4.2.0",
+                "@smithy/util-endpoints": "^3.2.6",
+                "@smithy/util-middleware": "^4.2.6",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/core": {
+            "version": "3.19.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.19.0.tgz",
+            "integrity": "sha512-Y9oHXpBcXQgYHOcAEmxjkDilUbSTkgKjoHYed3WaYUH8jngq8lPWDBSpjHblJ9uOgBdy5mh3pzebrScDdYr29w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.2.7",
+                "@smithy/protocol-http": "^5.3.6",
+                "@smithy/types": "^4.10.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-middleware": "^4.2.6",
+                "@smithy/util-stream": "^4.5.7",
+                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/uuid": "^1.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.6.tgz",
+            "integrity": "sha512-xBmawExyTzOjbhzkZwg+vVm/khg28kG+rj2sbGlULjFd1jI70sv/cbpaR0Ev4Yfd6CpDUDRMe64cTqR//wAOyA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.6",
+                "@smithy/property-provider": "^4.2.6",
+                "@smithy/types": "^4.10.0",
+                "@smithy/url-parser": "^4.2.6",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.7.tgz",
+            "integrity": "sha512-fcVap4QwqmzQwQK9QU3keeEpCzTjnP9NJ171vI7GnD7nbkAIcP9biZhDUx88uRH9BabSsQDS0unUps88uZvFIQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.6",
+                "@smithy/querystring-builder": "^4.2.6",
+                "@smithy/types": "^4.10.0",
+                "@smithy/util-base64": "^4.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/hash-node": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.6.tgz",
+            "integrity": "sha512-k3Dy9VNR37wfMh2/1RHkFf/e0rMyN0pjY0FdyY6ItJRjENYyVPRMwad6ZR1S9HFm6tTuIOd9pqKBmtJ4VHxvxg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.10.0",
+                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/invalid-dependency": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.6.tgz",
+            "integrity": "sha512-E4t/V/q2T46RY21fpfznd1iSLTvCXKNKo4zJ1QuEFN4SE9gKfu2vb6bgq35LpufkQ+SETWIC7ZAf2GGvTlBaMQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+            "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-content-length": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.6.tgz",
+            "integrity": "sha512-0cjqjyfj+Gls30ntq45SsBtqF3dfJQCeqQPyGz58Pk8OgrAr5YiB7ZvDzjCA94p4r6DCI4qLm7FKobqBjf515w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.6",
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-endpoint": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.0.tgz",
+            "integrity": "sha512-M6qWfUNny6NFNy8amrCGIb9TfOMUkHVtg9bHtEFGRgfH7A7AtPpn/fcrToGPjVDK1ECuMVvqGQOXcZxmu9K+7A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.19.0",
+                "@smithy/middleware-serde": "^4.2.7",
+                "@smithy/node-config-provider": "^4.3.6",
+                "@smithy/shared-ini-file-loader": "^4.4.1",
+                "@smithy/types": "^4.10.0",
+                "@smithy/url-parser": "^4.2.6",
+                "@smithy/util-middleware": "^4.2.6",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry": {
+            "version": "4.4.16",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.16.tgz",
+            "integrity": "sha512-XPpNhNRzm3vhYm7YCsyw3AtmWggJbg1wNGAoqb7NBYr5XA5isMRv14jgbYyUV6IvbTBFZQdf2QpeW43LrRdStQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.6",
+                "@smithy/protocol-http": "^5.3.6",
+                "@smithy/service-error-classification": "^4.2.6",
+                "@smithy/smithy-client": "^4.10.1",
+                "@smithy/types": "^4.10.0",
+                "@smithy/util-middleware": "^4.2.6",
+                "@smithy/util-retry": "^4.2.6",
+                "@smithy/uuid": "^1.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-serde": {
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.7.tgz",
+            "integrity": "sha512-PFMVHVPgtFECeu4iZ+4SX6VOQT0+dIpm4jSPLLL6JLSkp9RohGqKBKD0cbiXdeIFS08Forp0UHI6kc0gIHenSA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.6",
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-stack": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.6.tgz",
+            "integrity": "sha512-JSbALU3G+JS4kyBZPqnJ3hxIYwOVRV7r9GNQMS6j5VsQDo5+Es5nddLfr9TQlxZLNHPvKSh+XSB0OuWGfSWFcA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/node-config-provider": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.6.tgz",
+            "integrity": "sha512-fYEyL59Qe82Ha1p97YQTMEQPJYmBS+ux76foqluaTVWoG9Px5J53w6NvXZNE3wP7lIicLDF7Vj1Em18XTX7fsA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.2.6",
+                "@smithy/shared-ini-file-loader": "^4.4.1",
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler": {
+            "version": "4.4.6",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
+            "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^4.2.6",
+                "@smithy/protocol-http": "^5.3.6",
+                "@smithy/querystring-builder": "^4.2.6",
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/property-provider": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.6.tgz",
+            "integrity": "sha512-a/tGSLPtaia2krbRdwR4xbZKO8lU67DjMk/jfY4QKt4PRlKML+2tL/gmAuhNdFDioO6wOq0sXkfnddNFH9mNUA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/protocol-http": {
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
+            "integrity": "sha512-qLRZzP2+PqhE3OSwvY2jpBbP0WKTZ9opTsn+6IWYI0SKVpbG+imcfNxXPq9fj5XeaUTr7odpsNpK6dmoiM1gJQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-builder": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
+            "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.10.0",
+                "@smithy/util-uri-escape": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-parser": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.6.tgz",
+            "integrity": "sha512-YmWxl32SQRw/kIRccSOxzS/Ib8/b5/f9ex0r5PR40jRJg8X1wgM3KrR2In+8zvOGVhRSXgvyQpw9yOSlmfmSnA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/service-error-classification": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.6.tgz",
+            "integrity": "sha512-Q73XBrzJlGTut2nf5RglSntHKgAG0+KiTJdO5QQblLfr4TdliGwIAha1iZIjwisc3rA5ulzqwwsYC6xrclxVQg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.10.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.1.tgz",
+            "integrity": "sha512-tph+oQYPbpN6NamF030hx1gb5YN2Plog+GLaRHpoEDwp8+ZPG26rIJvStG9hkWzN2HBn3HcWg0sHeB0tmkYzqA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4": {
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.6.tgz",
+            "integrity": "sha512-P1TXDHuQMadTMTOBv4oElZMURU4uyEhxhHfn+qOc2iofW9Rd4sZtBGx58Lzk112rIGVEYZT8eUMK4NftpewpRA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.2.0",
+                "@smithy/protocol-http": "^5.3.6",
+                "@smithy/types": "^4.10.0",
+                "@smithy/util-hex-encoding": "^4.2.0",
+                "@smithy/util-middleware": "^4.2.6",
+                "@smithy/util-uri-escape": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/smithy-client": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.1.tgz",
+            "integrity": "sha512-1ovWdxzYprhq+mWqiGZlt3kF69LJthuQcfY9BIyHx9MywTFKzFapluku1QXoaBB43GCsLDxNqS+1v30ure69AA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.19.0",
+                "@smithy/middleware-endpoint": "^4.4.0",
+                "@smithy/middleware-stack": "^4.2.6",
+                "@smithy/protocol-http": "^5.3.6",
+                "@smithy/types": "^4.10.0",
+                "@smithy/util-stream": "^4.5.7",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/types": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
+            "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/url-parser": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.6.tgz",
+            "integrity": "sha512-tVoyzJ2vXp4R3/aeV4EQjBDmCuWxRa8eo3KybL7Xv4wEM16nObYh7H1sNfcuLWHAAAzb0RVyxUz1S3sGj4X+Tg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.2.6",
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-base64": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+            "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-browser": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+            "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-node": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+            "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+            "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-config-provider": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+            "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.3.15",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.15.tgz",
+            "integrity": "sha512-LiZQVAg/oO8kueX4c+oMls5njaD2cRLXRfcjlTYjhIqmwHnCwkQO5B3dMQH0c5PACILxGAQf6Mxsq7CjlDc76A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.2.6",
+                "@smithy/smithy-client": "^4.10.1",
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.2.18",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.18.tgz",
+            "integrity": "sha512-Kw2J+KzYm9C9Z9nY6+W0tEnoZOofstVCMTshli9jhQbQCy64rueGfKzPfuFBnVUqZD9JobxTh2DzHmPkp/Va/Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^4.4.4",
+                "@smithy/credential-provider-imds": "^4.2.6",
+                "@smithy/node-config-provider": "^4.3.6",
+                "@smithy/property-provider": "^4.2.6",
+                "@smithy/smithy-client": "^4.10.1",
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-endpoints": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.6.tgz",
+            "integrity": "sha512-v60VNM2+mPvgHCBXEfMCYrQ0RepP6u6xvbAkMenfe4Mi872CqNkJzgcnQL837e8NdeDxBgrWQRTluKq5Lqdhfg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.6",
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-hex-encoding": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+            "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-middleware": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.6.tgz",
+            "integrity": "sha512-qrvXUkxBSAFomM3/OEMuDVwjh4wtqK8D2uDZPShzIqOylPst6gor2Cdp6+XrH4dyksAWq/bE2aSDYBTTnj0Rxg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-retry": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.6.tgz",
+            "integrity": "sha512-x7CeDQLPQ9cb6xN7fRJEjlP9NyGW/YeXWc4j/RUhg4I+H60F0PEeRc2c/z3rm9zmsdiMFzpV/rT+4UHW6KM1SA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.2.6",
+                "@smithy/types": "^4.10.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-stream": {
+            "version": "4.5.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.7.tgz",
+            "integrity": "sha512-Uuy4S5Aj4oF6k1z+i2OtIBJUns4mlg29Ph4S+CqjR+f4XXpSFVgTCYLzMszHJTicYDBxKFtwq2/QSEDSS5l02A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.3.7",
+                "@smithy/node-http-handler": "^4.4.6",
+                "@smithy/types": "^4.10.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-hex-encoding": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-uri-escape": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+            "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+            "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/uuid": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+            "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@types/babel__core": {
+            "version": "7.20.5",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "node_modules/@types/babel__generator": {
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+            "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__template": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__traverse": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+            "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.2"
+            }
+        },
+        "node_modules/@types/istanbul-lib-coverage": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+            "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/istanbul-lib-report": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+            "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/istanbul-lib-coverage": "*"
+            }
+        },
+        "node_modules/@types/istanbul-reports": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+            "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/istanbul-lib-report": "*"
+            }
+        },
+        "node_modules/@types/jest": {
+            "version": "30.0.0",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+            "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "expect": "^30.0.0",
+                "pretty-format": "^30.0.0"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "24.7.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.1.tgz",
+            "integrity": "sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~7.14.0"
+            }
+        },
+        "node_modules/@types/stack-utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+            "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/yargs": {
+            "version": "17.0.33",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+            "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/yargs-parser": "*"
+            }
+        },
+        "node_modules/@types/yargs-parser": {
+            "version": "21.0.3",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+            "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+            "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+            "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-android-arm64": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+            "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-darwin-arm64": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+            "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-darwin-x64": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+            "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-freebsd-x64": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+            "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+            "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+            "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+            "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+            "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+            "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+            "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+            "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+            "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+            "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+            "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+            "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^0.2.11"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+            "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+            "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+            "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/anymatch": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/babel-jest": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
+            "integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/transform": "30.2.0",
+                "@types/babel__core": "^7.20.5",
+                "babel-plugin-istanbul": "^7.0.1",
+                "babel-preset-jest": "30.2.0",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.11.0 || ^8.0.0-0"
+            }
+        },
+        "node_modules/babel-plugin-istanbul": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+            "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "workspaces": [
+                "test/babel-8"
+            ],
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@istanbuljs/load-nyc-config": "^1.0.0",
+                "@istanbuljs/schema": "^0.1.3",
+                "istanbul-lib-instrument": "^6.0.2",
+                "test-exclude": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/babel-plugin-jest-hoist": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.2.0.tgz",
+            "integrity": "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/babel__core": "^7.20.5"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/babel-preset-current-node-syntax": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+            "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-bigint": "^7.8.3",
+                "@babel/plugin-syntax-class-properties": "^7.12.13",
+                "@babel/plugin-syntax-class-static-block": "^7.14.5",
+                "@babel/plugin-syntax-import-attributes": "^7.24.7",
+                "@babel/plugin-syntax-import-meta": "^7.10.4",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+                "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+                "@babel/plugin-syntax-top-level-await": "^7.14.5"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0 || ^8.0.0-0"
+            }
+        },
+        "node_modules/babel-preset-jest": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.2.0.tgz",
+            "integrity": "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "babel-plugin-jest-hoist": "30.2.0",
+                "babel-preset-current-node-syntax": "^1.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.8.18",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.18.tgz",
+            "integrity": "sha512-UYmTpOBwgPScZpS4A+YbapwWuBwasxvO/2IOHArSsAhL/+ZdmATBXTex3t+l2hXwLVYK382ibr/nKoY9GKe86w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.js"
+            }
+        },
+        "node_modules/bowser": {
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
+            "integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==",
+            "license": "MIT"
+        },
+        "node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/browserslist": {
+            "version": "4.26.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
+            "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "baseline-browser-mapping": "^2.8.9",
+                "caniuse-lite": "^1.0.30001746",
+                "electron-to-chromium": "^1.5.227",
+                "node-releases": "^2.0.21",
+                "update-browserslist-db": "^1.1.3"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
+        "node_modules/bs-logger": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+            "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-json-stable-stringify": "2.x"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/bser": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+            "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "node-int64": "^0.4.0"
+            }
+        },
+        "node_modules/buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001751",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+            "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/char-regex": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/ci-info": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+            "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cjs-module-lexer": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/cliui/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "iojs": ">= 1.0.0",
+                "node": ">= 0.12.0"
+            }
+        },
+        "node_modules/collect-v8-coverage": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+            "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/dedent": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
+            "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "babel-plugin-macros": "^3.1.0"
+            },
+            "peerDependenciesMeta": {
+                "babel-plugin-macros": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/deepmerge": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/detect-newline": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+            "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/electron-to-chromium": {
+            "version": "1.5.237",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.237.tgz",
+            "integrity": "sha512-icUt1NvfhGLar5lSWH3tHNzablaA5js3HVHacQimfP8ViEBOQv+L7DKEuHdbTZ0SKCO1ogTJTIL1Gwk9S6Qvcg==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/emittery": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+            "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/execa/node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/exit-x": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+            "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/expect": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
+            "integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/expect-utils": "30.2.0",
+                "@jest/get-type": "30.1.0",
+                "jest-matcher-utils": "30.2.0",
+                "jest-message-util": "30.2.0",
+                "jest-mock": "30.2.0",
+                "jest-util": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "strnum": "^2.1.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
+        "node_modules/fb-watchman": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+            "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bser": "2.1.1"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-package-type": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+            "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/glob": {
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/handlebars": {
+            "version": "4.7.8",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.2",
+                "source-map": "^0.6.1",
+                "wordwrap": "^1.0.0"
+            },
+            "bin": {
+                "handlebars": "bin/handlebars"
+            },
+            "engines": {
+                "node": ">=0.4.7"
+            },
+            "optionalDependencies": {
+                "uglify-js": "^3.1.4"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
+        "node_modules/import-local": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+            "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pkg-dir": "^4.2.0",
+                "resolve-cwd": "^3.0.0"
+            },
+            "bin": {
+                "import-local-fixture": "fixtures/cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.19"
+            }
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-generator-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/istanbul-lib-coverage": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-instrument": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+            "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@babel/core": "^7.23.9",
+                "@babel/parser": "^7.23.9",
+                "@istanbuljs/schema": "^0.1.3",
+                "istanbul-lib-coverage": "^3.2.0",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-lib-instrument/node_modules/semver": {
+            "version": "7.7.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-lib-report": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^4.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-lib-source-maps": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+            "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.23",
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-reports": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+            "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/jest": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
+            "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/core": "30.2.0",
+                "@jest/types": "30.2.0",
+                "import-local": "^3.2.0",
+                "jest-cli": "30.2.0"
+            },
+            "bin": {
+                "jest": "bin/jest.js"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-changed-files": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.2.0.tgz",
+            "integrity": "sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "execa": "^5.1.1",
+                "jest-util": "30.2.0",
+                "p-limit": "^3.1.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-circus": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.2.0.tgz",
+            "integrity": "sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.2.0",
+                "@jest/expect": "30.2.0",
+                "@jest/test-result": "30.2.0",
+                "@jest/types": "30.2.0",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "co": "^4.6.0",
+                "dedent": "^1.6.0",
+                "is-generator-fn": "^2.1.0",
+                "jest-each": "30.2.0",
+                "jest-matcher-utils": "30.2.0",
+                "jest-message-util": "30.2.0",
+                "jest-runtime": "30.2.0",
+                "jest-snapshot": "30.2.0",
+                "jest-util": "30.2.0",
+                "p-limit": "^3.1.0",
+                "pretty-format": "30.2.0",
+                "pure-rand": "^7.0.0",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.6"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-cli": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.2.0.tgz",
+            "integrity": "sha512-Os9ukIvADX/A9sLt6Zse3+nmHtHaE6hqOsjQtNiugFTbKRHYIYtZXNGNK9NChseXy7djFPjndX1tL0sCTlfpAA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/core": "30.2.0",
+                "@jest/test-result": "30.2.0",
+                "@jest/types": "30.2.0",
+                "chalk": "^4.1.2",
+                "exit-x": "^0.2.2",
+                "import-local": "^3.2.0",
+                "jest-config": "30.2.0",
+                "jest-util": "30.2.0",
+                "jest-validate": "30.2.0",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "jest": "bin/jest.js"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-config": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.2.0.tgz",
+            "integrity": "sha512-g4WkyzFQVWHtu6uqGmQR4CQxz/CH3yDSlhzXMWzNjDx843gYjReZnMRanjRCq5XZFuQrGDxgUaiYWE8BRfVckA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.27.4",
+                "@jest/get-type": "30.1.0",
+                "@jest/pattern": "30.0.1",
+                "@jest/test-sequencer": "30.2.0",
+                "@jest/types": "30.2.0",
+                "babel-jest": "30.2.0",
+                "chalk": "^4.1.2",
+                "ci-info": "^4.2.0",
+                "deepmerge": "^4.3.1",
+                "glob": "^10.3.10",
+                "graceful-fs": "^4.2.11",
+                "jest-circus": "30.2.0",
+                "jest-docblock": "30.2.0",
+                "jest-environment-node": "30.2.0",
+                "jest-regex-util": "30.0.1",
+                "jest-resolve": "30.2.0",
+                "jest-runner": "30.2.0",
+                "jest-util": "30.2.0",
+                "jest-validate": "30.2.0",
+                "micromatch": "^4.0.8",
+                "parse-json": "^5.2.0",
+                "pretty-format": "30.2.0",
+                "slash": "^3.0.0",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@types/node": "*",
+                "esbuild-register": ">=3.4.0",
+                "ts-node": ">=9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "esbuild-register": {
+                    "optional": true
+                },
+                "ts-node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-diff": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
+            "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/diff-sequences": "30.0.1",
+                "@jest/get-type": "30.1.0",
+                "chalk": "^4.1.2",
+                "pretty-format": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-docblock": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
+            "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "detect-newline": "^3.1.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-each": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.2.0.tgz",
+            "integrity": "sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0",
+                "@jest/types": "30.2.0",
+                "chalk": "^4.1.2",
+                "jest-util": "30.2.0",
+                "pretty-format": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-environment-node": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.2.0.tgz",
+            "integrity": "sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.2.0",
+                "@jest/fake-timers": "30.2.0",
+                "@jest/types": "30.2.0",
+                "@types/node": "*",
+                "jest-mock": "30.2.0",
+                "jest-util": "30.2.0",
+                "jest-validate": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-haste-map": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.2.0.tgz",
+            "integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.2.0",
+                "@types/node": "*",
+                "anymatch": "^3.1.3",
+                "fb-watchman": "^2.0.2",
+                "graceful-fs": "^4.2.11",
+                "jest-regex-util": "30.0.1",
+                "jest-util": "30.2.0",
+                "jest-worker": "30.2.0",
+                "micromatch": "^4.0.8",
+                "walker": "^1.0.8"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "^2.3.3"
+            }
+        },
+        "node_modules/jest-leak-detector": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.2.0.tgz",
+            "integrity": "sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0",
+                "pretty-format": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-matcher-utils": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
+            "integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0",
+                "chalk": "^4.1.2",
+                "jest-diff": "30.2.0",
+                "pretty-format": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-message-util": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+            "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "@jest/types": "30.2.0",
+                "@types/stack-utils": "^2.0.3",
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "micromatch": "^4.0.8",
+                "pretty-format": "30.2.0",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.6"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-mock": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+            "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.2.0",
+                "@types/node": "*",
+                "jest-util": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-pnp-resolver": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+            "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "peerDependencies": {
+                "jest-resolve": "*"
+            },
+            "peerDependenciesMeta": {
+                "jest-resolve": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-regex-util": {
+            "version": "30.0.1",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+            "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-resolve": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.2.0.tgz",
+            "integrity": "sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.2",
+                "graceful-fs": "^4.2.11",
+                "jest-haste-map": "30.2.0",
+                "jest-pnp-resolver": "^1.2.3",
+                "jest-util": "30.2.0",
+                "jest-validate": "30.2.0",
+                "slash": "^3.0.0",
+                "unrs-resolver": "^1.7.11"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-resolve-dependencies": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.2.0.tgz",
+            "integrity": "sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "jest-regex-util": "30.0.1",
+                "jest-snapshot": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-runner": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.2.0.tgz",
+            "integrity": "sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/console": "30.2.0",
+                "@jest/environment": "30.2.0",
+                "@jest/test-result": "30.2.0",
+                "@jest/transform": "30.2.0",
+                "@jest/types": "30.2.0",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "emittery": "^0.13.1",
+                "exit-x": "^0.2.2",
+                "graceful-fs": "^4.2.11",
+                "jest-docblock": "30.2.0",
+                "jest-environment-node": "30.2.0",
+                "jest-haste-map": "30.2.0",
+                "jest-leak-detector": "30.2.0",
+                "jest-message-util": "30.2.0",
+                "jest-resolve": "30.2.0",
+                "jest-runtime": "30.2.0",
+                "jest-util": "30.2.0",
+                "jest-watcher": "30.2.0",
+                "jest-worker": "30.2.0",
+                "p-limit": "^3.1.0",
+                "source-map-support": "0.5.13"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-runtime": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.2.0.tgz",
+            "integrity": "sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/environment": "30.2.0",
+                "@jest/fake-timers": "30.2.0",
+                "@jest/globals": "30.2.0",
+                "@jest/source-map": "30.0.1",
+                "@jest/test-result": "30.2.0",
+                "@jest/transform": "30.2.0",
+                "@jest/types": "30.2.0",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "cjs-module-lexer": "^2.1.0",
+                "collect-v8-coverage": "^1.0.2",
+                "glob": "^10.3.10",
+                "graceful-fs": "^4.2.11",
+                "jest-haste-map": "30.2.0",
+                "jest-message-util": "30.2.0",
+                "jest-mock": "30.2.0",
+                "jest-regex-util": "30.0.1",
+                "jest-resolve": "30.2.0",
+                "jest-snapshot": "30.2.0",
+                "jest-util": "30.2.0",
+                "slash": "^3.0.0",
+                "strip-bom": "^4.0.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-snapshot": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.2.0.tgz",
+            "integrity": "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.27.4",
+                "@babel/generator": "^7.27.5",
+                "@babel/plugin-syntax-jsx": "^7.27.1",
+                "@babel/plugin-syntax-typescript": "^7.27.1",
+                "@babel/types": "^7.27.3",
+                "@jest/expect-utils": "30.2.0",
+                "@jest/get-type": "30.1.0",
+                "@jest/snapshot-utils": "30.2.0",
+                "@jest/transform": "30.2.0",
+                "@jest/types": "30.2.0",
+                "babel-preset-current-node-syntax": "^1.2.0",
+                "chalk": "^4.1.2",
+                "expect": "30.2.0",
+                "graceful-fs": "^4.2.11",
+                "jest-diff": "30.2.0",
+                "jest-matcher-utils": "30.2.0",
+                "jest-message-util": "30.2.0",
+                "jest-util": "30.2.0",
+                "pretty-format": "30.2.0",
+                "semver": "^7.7.2",
+                "synckit": "^0.11.8"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-snapshot/node_modules/semver": {
+            "version": "7.7.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/jest-util": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+            "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/types": "30.2.0",
+                "@types/node": "*",
+                "chalk": "^4.1.2",
+                "ci-info": "^4.2.0",
+                "graceful-fs": "^4.2.11",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-util/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/jest-validate": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.2.0.tgz",
+            "integrity": "sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/get-type": "30.1.0",
+                "@jest/types": "30.2.0",
+                "camelcase": "^6.3.0",
+                "chalk": "^4.1.2",
+                "leven": "^3.1.0",
+                "pretty-format": "30.2.0"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-validate/node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/jest-watcher": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.2.0.tgz",
+            "integrity": "sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/test-result": "30.2.0",
+                "@jest/types": "30.2.0",
+                "@types/node": "*",
+                "ansi-escapes": "^4.3.2",
+                "chalk": "^4.1.2",
+                "emittery": "^0.13.1",
+                "jest-util": "30.2.0",
+                "string-length": "^4.0.2"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-worker": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.2.0.tgz",
+            "integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@ungap/structured-clone": "^1.3.0",
+                "jest-util": "30.2.0",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.1.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-worker/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsesc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/leven": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/make-dir": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/make-dir/node_modules/semver": {
+            "version": "7.7.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/makeerror": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+            "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tmpl": "1.0.5"
+            }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/napi-postinstall": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+            "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "napi-postinstall": "lib/cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/napi-postinstall"
+            }
+        },
+        "node_modules/natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/node-int64": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/node-releases": {
+            "version": "2.0.26",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.26.tgz",
+            "integrity": "sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/p-locate/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
+        },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pirates": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+            "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/pkg-dir": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "find-up": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pretty-format": {
+            "version": "30.2.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+            "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/schemas": "30.0.5",
+                "ansi-styles": "^5.2.0",
+                "react-is": "^18.3.1"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/pure-rand": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+            "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/react-is": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/resolve-cwd": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+            "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve-from": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-support": {
+            "version": "0.5.13",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+            "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/stack-utils": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+            "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/string-length": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+            "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "char-regex": "^1.0.2",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/string-length/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-length/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/string-width-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-bom": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/strnum": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+            "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/synckit": {
+            "version": "0.11.11",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+            "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@pkgr/core": "^0.2.9"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/synckit"
+            }
+        },
+        "node_modules/test-exclude": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@istanbuljs/schema": "^0.1.2",
+                "glob": "^7.1.4",
+                "minimatch": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/test-exclude/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/test-exclude/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/test-exclude/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/tmpl": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+            "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/ts-jest": {
+            "version": "29.4.5",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.5.tgz",
+            "integrity": "sha512-HO3GyiWn2qvTQA4kTgjDcXiMwYQt68a1Y8+JuLRVpdIzm+UOLSHgl/XqR4c6nzJkq5rOkjc02O2I7P7l/Yof0Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bs-logger": "^0.2.6",
+                "fast-json-stable-stringify": "^2.1.0",
+                "handlebars": "^4.7.8",
+                "json5": "^2.2.3",
+                "lodash.memoize": "^4.1.2",
+                "make-error": "^1.3.6",
+                "semver": "^7.7.3",
+                "type-fest": "^4.41.0",
+                "yargs-parser": "^21.1.1"
+            },
+            "bin": {
+                "ts-jest": "cli.js"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": ">=7.0.0-beta.0 <8",
+                "@jest/transform": "^29.0.0 || ^30.0.0",
+                "@jest/types": "^29.0.0 || ^30.0.0",
+                "babel-jest": "^29.0.0 || ^30.0.0",
+                "jest": "^29.0.0 || ^30.0.0",
+                "jest-util": "^29.0.0 || ^30.0.0",
+                "typescript": ">=4.3 <6"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                },
+                "@jest/transform": {
+                    "optional": true
+                },
+                "@jest/types": {
+                    "optional": true
+                },
+                "babel-jest": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jest-util": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ts-jest/node_modules/semver": {
+            "version": "7.7.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/ts-jest/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
+        },
+        "node_modules/type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/uglify-js": {
+            "version": "3.19.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+            "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/unrs-resolver": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+            "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "napi-postinstall": "^0.3.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/unrs-resolver"
+            },
+            "optionalDependencies": {
+                "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+                "@unrs/resolver-binding-android-arm64": "1.11.1",
+                "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+                "@unrs/resolver-binding-darwin-x64": "1.11.1",
+                "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+                "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+                "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+                "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+                "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+                "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+                "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+                "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+                "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+                "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+                "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+                "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+                "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+                "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+            }
+        },
+        "node_modules/update-browserslist-db": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/v8-to-istanbul": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+            "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.12",
+                "@types/istanbul-lib-coverage": "^2.0.1",
+                "convert-source-map": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.12.0"
+            }
+        },
+        "node_modules/walker": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+            "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "makeerror": "1.0.12"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/write-file-atomic": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+            "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/yargs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        }
+    }
+}

--- a/cdk/lib/lambda/node/RegisterTenant/package-lock.json
+++ b/cdk/lib/lambda/node/RegisterTenant/package-lock.json
@@ -2653,9 +2653,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2670,9 +2667,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2687,9 +2681,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2704,9 +2695,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2721,9 +2709,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2738,9 +2723,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [

--- a/cdk/lib/lambda/node/RegisterTenant/package-lock.json
+++ b/cdk/lib/lambda/node/RegisterTenant/package-lock.json
@@ -10,6 +10,9 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/client-cognito-identity-provider": "^3.908.0",
+                "@platelet-app/graphql": "^1.1.10",
+                "@platelet-app/lambda": "^1.1.17",
+                "@platelet-app/types": "^1.1.4",
                 "uuid": "^14.0.1"
             },
             "devDependencies": {
@@ -17,6 +20,34 @@
                 "jest": "^30.2.0",
                 "ts-jest": "^29.4.5"
             }
+        },
+        "node_modules/@aws-crypto/crc32": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+            "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^3.0.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/crc32/node_modules/@aws-crypto/util": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+            "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "license": "0BSD"
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "5.2.0",
@@ -96,6 +127,23 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+            "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^1.2.2",
+                "@aws-sdk/types": "^3.1.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "license": "0BSD"
+        },
         "node_modules/@aws-crypto/supports-web-crypto": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
@@ -103,6 +151,93 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
+            "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.1.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "license": "0BSD"
+        },
+        "node_modules/@aws-sdk/checksums": {
+            "version": "3.1000.26",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.26.tgz",
+            "integrity": "sha512-CGznePoL+1oWCSzqmkvlYMpWQEZohPR3LntjKXXfVH+oh6Kd8d+yHLkjpiAGwPIHAxFe4OAq3aKfRnv/wqWIyA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/checksums/node_modules/@aws-sdk/core": {
+            "version": "3.977.6",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+            "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/xml-builder": "^3.972.37",
+                "@aws/lambda-invoke-store": "^0.3.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/signature-v4": "^5.6.12",
+                "@smithy/types": "^4.16.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/checksums/node_modules/@aws-sdk/types": {
+            "version": "3.974.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+            "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/checksums/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.37",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+            "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/checksums/node_modules/@aws/lambda-invoke-store": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+            "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/client-cognito-identity-provider": {
@@ -216,6 +351,729 @@
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3": {
+            "version": "3.1106.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1106.0.tgz",
+            "integrity": "sha512-hUTlnyRRGlVdfvJLL3hCEnMm7CmunSzc/lxFVRX8g1fjJTMUVbyQCfhfMhp7dZ7JBftLU6OYresu3Hje4nvkJw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/checksums": "^3.1000.26",
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/credential-provider-node": "^3.972.78",
+                "@aws-sdk/middleware-sdk-s3": "^3.972.72",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/core": {
+            "version": "3.977.6",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+            "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/xml-builder": "^3.972.37",
+                "@aws/lambda-invoke-store": "^0.3.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/signature-v4": "^5.6.12",
+                "@smithy/types": "^4.16.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.972.67",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+            "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.972.69",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+            "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.973.12",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+            "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/credential-provider-env": "^3.972.67",
+                "@aws-sdk/credential-provider-http": "^3.972.69",
+                "@aws-sdk/credential-provider-login": "^3.972.74",
+                "@aws-sdk/credential-provider-process": "^3.972.67",
+                "@aws-sdk/credential-provider-sso": "^3.973.11",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/credential-provider-imds": "^4.4.16",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.972.78",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+            "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "^3.972.67",
+                "@aws-sdk/credential-provider-http": "^3.972.69",
+                "@aws-sdk/credential-provider-ini": "^3.973.12",
+                "@aws-sdk/credential-provider-process": "^3.972.67",
+                "@aws-sdk/credential-provider-sso": "^3.973.11",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/credential-provider-imds": "^4.4.16",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.972.67",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+            "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.973.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+            "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/token-providers": "3.1103.0",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.972.73",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+            "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/nested-clients": {
+            "version": "3.997.41",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+            "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
+            "version": "3.1103.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+            "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
+            "version": "3.974.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+            "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.37",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+            "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws/lambda-invoke-store": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+            "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses": {
+            "version": "3.1106.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.1106.0.tgz",
+            "integrity": "sha512-aY916g3lCClMXBA5eHmod6q6qOlEVymySYcYm4eNGO2uL1xGsBgQ5h0V3GUAMnzZGSMpCRS2n5dJq9xl/lrJ+w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/credential-provider-node": "^3.972.78",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/core": {
+            "version": "3.977.6",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+            "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/xml-builder": "^3.972.37",
+                "@aws/lambda-invoke-store": "^0.3.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/signature-v4": "^5.6.12",
+                "@smithy/types": "^4.16.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.972.67",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+            "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.972.69",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+            "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.973.12",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+            "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/credential-provider-env": "^3.972.67",
+                "@aws-sdk/credential-provider-http": "^3.972.69",
+                "@aws-sdk/credential-provider-login": "^3.972.74",
+                "@aws-sdk/credential-provider-process": "^3.972.67",
+                "@aws-sdk/credential-provider-sso": "^3.973.11",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/credential-provider-imds": "^4.4.16",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.972.78",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+            "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "^3.972.67",
+                "@aws-sdk/credential-provider-http": "^3.972.69",
+                "@aws-sdk/credential-provider-ini": "^3.973.12",
+                "@aws-sdk/credential-provider-process": "^3.972.67",
+                "@aws-sdk/credential-provider-sso": "^3.973.11",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/credential-provider-imds": "^4.4.16",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.972.67",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+            "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.973.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+            "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/token-providers": "3.1103.0",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.972.73",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+            "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/nested-clients": {
+            "version": "3.997.41",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+            "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/token-providers": {
+            "version": "3.1103.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+            "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/types": {
+            "version": "3.974.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+            "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.37",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+            "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ses/node_modules/@aws/lambda-invoke-store": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+            "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm": {
+            "version": "3.1106.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1106.0.tgz",
+            "integrity": "sha512-jPGMnYT+XtpXnnXzOBm9zBg+o4+vGQClj8TtDKZzX6sGFVcEunQEL1dZHn5iRy3z5vaGN+T7ch4zgI9A2WJkfA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/credential-provider-node": "^3.972.78",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/core": {
+            "version": "3.977.6",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+            "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/xml-builder": "^3.972.37",
+                "@aws/lambda-invoke-store": "^0.3.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/signature-v4": "^5.6.12",
+                "@smithy/types": "^4.16.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.972.67",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+            "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.972.69",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+            "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.973.12",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+            "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/credential-provider-env": "^3.972.67",
+                "@aws-sdk/credential-provider-http": "^3.972.69",
+                "@aws-sdk/credential-provider-login": "^3.972.74",
+                "@aws-sdk/credential-provider-process": "^3.972.67",
+                "@aws-sdk/credential-provider-sso": "^3.973.11",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/credential-provider-imds": "^4.4.16",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.972.78",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+            "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "^3.972.67",
+                "@aws-sdk/credential-provider-http": "^3.972.69",
+                "@aws-sdk/credential-provider-ini": "^3.973.12",
+                "@aws-sdk/credential-provider-process": "^3.972.67",
+                "@aws-sdk/credential-provider-sso": "^3.973.11",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/credential-provider-imds": "^4.4.16",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.972.67",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+            "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.973.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+            "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/token-providers": "3.1103.0",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.972.73",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+            "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/nested-clients": {
+            "version": "3.997.41",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+            "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/token-providers": {
+            "version": "3.1103.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+            "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/types": {
+            "version": "3.974.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+            "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.37",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+            "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws/lambda-invoke-store": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+            "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/client-sso": {
@@ -415,6 +1273,96 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/@aws-sdk/credential-provider-login": {
+            "version": "3.972.74",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+            "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/core": {
+            "version": "3.977.6",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+            "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/xml-builder": "^3.972.37",
+                "@aws/lambda-invoke-store": "^0.3.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/signature-v4": "^5.6.12",
+                "@smithy/types": "^4.16.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/nested-clients": {
+            "version": "3.997.41",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+            "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/types": {
+            "version": "3.974.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+            "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.37",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+            "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws/lambda-invoke-store": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+            "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@aws-sdk/credential-provider-node": {
             "version": "3.908.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.908.0.tgz",
@@ -492,6 +1440,55 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/@aws-sdk/eventstream-codec": {
+            "version": "3.370.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.370.0.tgz",
+            "integrity": "sha512-PiaDMum7TNsIE3DGECSsNYwibBIPN2/e13BJbTwi6KgVx8BV2mYA3kQkaUDiy++tEpzN81Nh5OPTFVb7bvgYYg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/crc32": "3.0.0",
+                "@aws-sdk/types": "3.370.0",
+                "@aws-sdk/util-hex-encoding": "3.310.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/types": {
+            "version": "3.370.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
+            "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/eventstream-codec/node_modules/@smithy/types": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+            "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/is-array-buffer": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+            "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.901.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.901.0.tgz",
@@ -533,6 +1530,77 @@
                 "@smithy/types": "^4.6.0",
                 "tslib": "^2.6.2"
             },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-s3": {
+            "version": "3.972.72",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.72.tgz",
+            "integrity": "sha512-lSAoVPvQxX1d8TOM6waKDBQrvvZcm4w6pCldFAsRUffEaXq6lYY0pPyew3KlLu6Xqb74DXI42hGvSsbGBLljlw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/core": {
+            "version": "3.977.6",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+            "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/xml-builder": "^3.972.37",
+                "@aws/lambda-invoke-store": "^0.3.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/signature-v4": "^5.6.12",
+                "@smithy/types": "^4.16.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
+            "version": "3.974.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+            "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.37",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+            "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws/lambda-invoke-store": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+            "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.0.0"
             }
@@ -667,6 +1735,44 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@aws-sdk/protocol-http": {
+            "version": "3.370.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.370.0.tgz",
+            "integrity": "sha512-MfZCgSsVmir+4kJps7xT0awOPNi+swBpcVp9ZtAP7POduUVV6zVLurMNLXsppKsErggssD5E9HUgQFs5w06U4Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.370.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/protocol-http/node_modules/@aws-sdk/types": {
+            "version": "3.370.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
+            "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/protocol-http/node_modules/@smithy/types": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+            "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.901.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.901.0.tgz",
@@ -682,6 +1788,78 @@
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4": {
+            "version": "3.370.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.370.0.tgz",
+            "integrity": "sha512-Mh++NJiXoBxMzz4d8GQPNB37nqjS1gsVwjKoSAWFE67sjgsjb8D5JWRCm9CinqPoXi2iN57+1DcQalTDKQGc0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/eventstream-codec": "3.370.0",
+                "@aws-sdk/is-array-buffer": "3.310.0",
+                "@aws-sdk/types": "3.370.0",
+                "@aws-sdk/util-hex-encoding": "3.310.0",
+                "@aws-sdk/util-middleware": "3.370.0",
+                "@aws-sdk/util-uri-escape": "3.310.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.996.43",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+            "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/signature-v4": "^5.6.12",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
+            "version": "3.974.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+            "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/types": {
+            "version": "3.370.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
+            "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4/node_modules/@smithy/types": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+            "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/token-providers": {
@@ -715,6 +1893,19 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/@aws-sdk/util-buffer-from": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+            "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@aws-sdk/util-endpoints": {
             "version": "3.901.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.901.0.tgz",
@@ -731,6 +1922,18 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/@aws-sdk/util-hex-encoding": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+            "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@aws-sdk/util-locate-window": {
             "version": "3.893.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.893.0.tgz",
@@ -741,6 +1944,30 @@
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-middleware": {
+            "version": "3.370.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.370.0.tgz",
+            "integrity": "sha512-Jvs9FZHaQznWGLkRel3PFEP93I1n0Kp6356zxYHk3LIOmjpzoob3R+v96mzyN+dZrnhPdPubYS41qbU2F9lROg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-uri-escape": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+            "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
@@ -777,6 +2004,28 @@
                 "aws-crt": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@aws-sdk/util-utf8": {
+            "version": "3.310.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+            "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/util-buffer-from": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-utf8-browser": {
+            "version": "3.259.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+            "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.3.1"
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
@@ -1806,6 +3055,36 @@
                 "url": "https://opencollective.com/pkgr"
             }
         },
+        "node_modules/@platelet-app/graphql": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/@platelet-app/graphql/-/graphql-1.1.10.tgz",
+            "integrity": "sha512-mMFstXJshRIW74NAblmuZ2nNnw1J/4Aq1aMnvN13ocSbuK78xpKPmCFU9wed7h/mxwL2RRYkd+1ppnX5gO+o/A==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@platelet-app/lambda": {
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/@platelet-app/lambda/-/lambda-1.1.17.tgz",
+            "integrity": "sha512-GiqhvFBCxzF0pYJA4aniYzk1QORrt5DszIdNy8jeDM0MG6D15ULnOgF9LXAMpoXy8BBFDLxFADS/F363RZRD0w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+                "@aws-sdk/client-s3": "^3.954.0",
+                "@aws-sdk/client-ses": "^3.946.0",
+                "@aws-sdk/client-ssm": "^3.1057.0",
+                "@aws-sdk/credential-provider-node": "^3.6.1",
+                "@aws-sdk/protocol-http": "^3.6.1",
+                "@aws-sdk/signature-v4": "^3.6.1",
+                "@platelet-app/types": "^1.1.2",
+                "@types/node-fetch": "^2.6.13",
+                "node-fetch": "^2.6.7"
+            }
+        },
+        "node_modules/@platelet-app/types": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@platelet-app/types/-/types-1.1.4.tgz",
+            "integrity": "sha512-KeEF+VeKn7Q/S82wFrbwUbROYCI4xWDgSEsMkQNcBrY6BpcdbkZY2+6Rxj4qk+A52VVtIlvgkClPnRC4rfsWsw==",
+            "license": "Apache-2.0"
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.34.41",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
@@ -1833,19 +3112,6 @@
                 "@sinonjs/commons": "^3.0.1"
             }
         },
-        "node_modules/@smithy/abort-controller": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.6.tgz",
-            "integrity": "sha512-P7JD4J+wxHMpGxqIg6SHno2tPkZbBUBLbPpR5/T1DEUvw/mEaINBMaPFZNM7lA+ToSCZ36j6nMHa+5kej+fhGg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.10.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
         "node_modules/@smithy/config-resolver": {
             "version": "4.4.4",
             "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.4.tgz",
@@ -1864,20 +3130,12 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.19.0",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.19.0.tgz",
-            "integrity": "sha512-Y9oHXpBcXQgYHOcAEmxjkDilUbSTkgKjoHYed3WaYUH8jngq8lPWDBSpjHblJ9uOgBdy5mh3pzebrScDdYr29w==",
+            "version": "3.31.1",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+            "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-serde": "^4.2.7",
-                "@smithy/protocol-http": "^5.3.6",
-                "@smithy/types": "^4.10.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.6",
-                "@smithy/util-stream": "^4.5.7",
-                "@smithy/util-utf8": "^4.2.0",
-                "@smithy/uuid": "^1.1.0",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1885,15 +3143,13 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.6.tgz",
-            "integrity": "sha512-xBmawExyTzOjbhzkZwg+vVm/khg28kG+rj2sbGlULjFd1jI70sv/cbpaR0Ev4Yfd6CpDUDRMe64cTqR//wAOyA==",
+            "version": "4.4.16",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+            "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.6",
-                "@smithy/property-provider": "^4.2.6",
-                "@smithy/types": "^4.10.0",
-                "@smithy/url-parser": "^4.2.6",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1901,15 +3157,13 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.7.tgz",
-            "integrity": "sha512-fcVap4QwqmzQwQK9QU3keeEpCzTjnP9NJ171vI7GnD7nbkAIcP9biZhDUx88uRH9BabSsQDS0unUps88uZvFIQ==",
+            "version": "5.6.13",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+            "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.6",
-                "@smithy/querystring-builder": "^4.2.6",
-                "@smithy/types": "^4.10.0",
-                "@smithy/util-base64": "^4.3.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2052,15 +3306,13 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.4.6",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-            "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+            "version": "4.9.13",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+            "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^4.2.6",
-                "@smithy/protocol-http": "^5.3.6",
-                "@smithy/querystring-builder": "^4.2.6",
-                "@smithy/types": "^4.10.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2087,20 +3339,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.10.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/querystring-builder": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-            "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.10.0",
-                "@smithy/util-uri-escape": "^4.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2146,18 +3384,13 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.3.6",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.6.tgz",
-            "integrity": "sha512-P1TXDHuQMadTMTOBv4oElZMURU4uyEhxhHfn+qOc2iofW9Rd4sZtBGx58Lzk112rIGVEYZT8eUMK4NftpewpRA==",
+            "version": "5.6.12",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+            "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.2.0",
-                "@smithy/protocol-http": "^5.3.6",
-                "@smithy/types": "^4.10.0",
-                "@smithy/util-hex-encoding": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.6",
-                "@smithy/util-uri-escape": "^4.2.0",
-                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2183,9 +3416,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.10.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-            "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+            "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -2376,18 +3609,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/util-uri-escape": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-            "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
         "node_modules/@smithy/util-utf8": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
@@ -2511,10 +3732,19 @@
             "version": "24.7.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.1.tgz",
             "integrity": "sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.14.0"
+            }
+        },
+        "node_modules/@types/node-fetch": {
+            "version": "2.6.13",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+            "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "form-data": "^4.0.4"
             }
         },
         "node_modules/@types/stack-utils": {
@@ -2886,6 +4116,12 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
+        },
         "node_modules/babel-jest": {
             "version": "30.2.0",
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
@@ -3095,6 +4331,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3302,6 +4551,18 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3374,6 +4635,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/detect-newline": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3382,6 +4652,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/eastasianwidth": {
@@ -3426,6 +4710,51 @@
             "license": "MIT",
             "dependencies": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/escalade": {
@@ -3600,6 +4929,22 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/form-data": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3622,6 +4967,15 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3642,6 +4996,30 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/get-package-type": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3650,6 +5028,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -3684,6 +5075,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/graceful-fs": {
@@ -3723,6 +5126,45 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/html-escaper": {
@@ -4701,6 +6143,15 @@
                 "tmpl": "1.0.5"
             }
         },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -4720,6 +6171,27 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/mimic-fn": {
@@ -4804,6 +6276,26 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/node-int64": {
             "version": "0.4.0",
@@ -5524,6 +7016,12 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
+        },
         "node_modules/ts-jest": {
             "version": "29.4.5",
             "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.5.tgz",
@@ -5665,7 +7163,6 @@
             "version": "7.14.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
             "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/unrs-resolver": {
@@ -5770,6 +7267,22 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "makeerror": "1.0.12"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {

--- a/cdk/lib/lambda/node/RegisterTenant/package-lock.json
+++ b/cdk/lib/lambda/node/RegisterTenant/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@aws-sdk/client-cognito-identity-provider": "^3.908.0",
                 "@platelet-app/graphql": "^1.1.10",
-                "@platelet-app/lambda": "^1.1.17",
+                "@platelet-app/lambda": "^1.1.19",
                 "@platelet-app/types": "^1.1.4",
                 "uuid": "^14.0.1"
             },
@@ -3062,15 +3062,15 @@
             "license": "Apache-2.0"
         },
         "node_modules/@platelet-app/lambda": {
-            "version": "1.1.17",
-            "resolved": "https://registry.npmjs.org/@platelet-app/lambda/-/lambda-1.1.17.tgz",
-            "integrity": "sha512-GiqhvFBCxzF0pYJA4aniYzk1QORrt5DszIdNy8jeDM0MG6D15ULnOgF9LXAMpoXy8BBFDLxFADS/F363RZRD0w==",
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/@platelet-app/lambda/-/lambda-1.1.19.tgz",
+            "integrity": "sha512-rQ8B1AprZV9GWdeGsE56vlPWqmC+d59EbuF4A3q91am2f+kuuka9hXn7OoDGNMw1hPNrdT4gOZcTE3uC/rHsdw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
                 "@aws-sdk/client-s3": "^3.954.0",
                 "@aws-sdk/client-ses": "^3.946.0",
-                "@aws-sdk/client-ssm": "^3.1057.0",
+                "@aws-sdk/client-ssm": "^3.1106.0",
                 "@aws-sdk/credential-provider-node": "^3.6.1",
                 "@aws-sdk/protocol-http": "^3.6.1",
                 "@aws-sdk/signature-v4": "^3.6.1",

--- a/cdk/lib/lambda/node/RegisterTenant/package.json
+++ b/cdk/lib/lambda/node/RegisterTenant/package.json
@@ -15,6 +15,9 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.908.0",
+        "@platelet-app/graphql": "^1.1.10",
+        "@platelet-app/lambda": "^1.1.17",
+        "@platelet-app/types": "^1.1.4",
         "uuid": "^14.0.1"
     },
     "devDependencies": {

--- a/cdk/lib/lambda/node/RegisterTenant/package.json
+++ b/cdk/lib/lambda/node/RegisterTenant/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.908.0",
         "@platelet-app/graphql": "^1.1.10",
-        "@platelet-app/lambda": "^1.1.17",
+        "@platelet-app/lambda": "^1.1.19",
         "@platelet-app/types": "^1.1.4",
         "uuid": "^14.0.1"
     },

--- a/cdk/lib/lambda/node/RegisterTenant/package.json
+++ b/cdk/lib/lambda/node/RegisterTenant/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "register-tenant",
+    "version": "1.0.0",
+    "description": "",
+    "type": "module",
+    "main": "index.js",
+    "scripts": {
+        "prebuild": "npm install --include=dev",
+        "build": "tsc",
+        "package": "npm prune --omit=dev && rm -rf dist/node_modules && cp -R node_modules dist/node_modules/ && cp package.json dist",
+        "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
+        "test:watch": "NODE_OPTIONS='--experimental-vm-modules' jest --watch"
+    },
+    "author": "Theo Cranmore <theo@platelet.app>",
+    "license": "Apache-2.0",
+    "dependencies": {
+        "@aws-sdk/client-cognito-identity-provider": "^3.908.0"
+    },
+    "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "jest": "^30.2.0",
+        "ts-jest": "^29.4.5"
+    }
+}

--- a/cdk/lib/lambda/node/RegisterTenant/package.json
+++ b/cdk/lib/lambda/node/RegisterTenant/package.json
@@ -14,7 +14,8 @@
     "author": "Theo Cranmore <theo@platelet.app>",
     "license": "Apache-2.0",
     "dependencies": {
-        "@aws-sdk/client-cognito-identity-provider": "^3.908.0"
+        "@aws-sdk/client-cognito-identity-provider": "^3.908.0",
+        "uuid": "^14.0.1"
     },
     "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/cdk/lib/lambda/node/RegisterTenant/package.json
+++ b/cdk/lib/lambda/node/RegisterTenant/package.json
@@ -22,6 +22,7 @@
     },
     "devDependencies": {
         "@types/jest": "^30.0.0",
+        "aws-sdk-client-mock": "^4.1.0",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.5"
     }

--- a/cdk/lib/lambda/node/RegisterTenant/setupTests.ts
+++ b/cdk/lib/lambda/node/RegisterTenant/setupTests.ts
@@ -1,0 +1,2 @@
+process.env.GRAPHQL_ENDPOINT = "https://api.example.com/graphql";
+process.env.USER_POOL_ID = "some_pool";

--- a/cdk/lib/lambda/node/RegisterTenant/setupTests.ts
+++ b/cdk/lib/lambda/node/RegisterTenant/setupTests.ts
@@ -1,2 +1,5 @@
 process.env.GRAPHQL_ENDPOINT = "https://api.example.com/graphql";
 process.env.USER_POOL_ID = "some_pool";
+process.env.REGION = "eu-west-1";
+process.env.AWS_ACCESS_KEY_ID = "someAccessKeyId";
+process.env.AWS_SECRET_ACCESS_KEY = "someSecretAccessKey";

--- a/cdk/lib/lambda/node/RegisterTenant/src/index.test.ts
+++ b/cdk/lib/lambda/node/RegisterTenant/src/index.test.ts
@@ -1,0 +1,65 @@
+import { jest, expect } from "@jest/globals";
+
+jest.unstable_mockModule("@platelet-app/lambda", () => ({
+    request: jest.fn(),
+    errorCheck: jest.fn(),
+    // @ts-ignore
+    getUserProfilePictures: jest.fn().mockResolvedValue({
+        Contents: [{ Key: "test-key" }, { Key: "test-key2" }],
+    }),
+}));
+
+jest.unstable_mockModule("@aws-sdk/client-cognito-identity-provider", () => {
+    // @ts-ignore
+    const mockSend = jest.fn().mockResolvedValue({});
+    const MockCognitoIdentityProviderClient = jest.fn(() => ({
+        send: mockSend,
+    }));
+    return {
+        CognitoIdentityProviderClient: MockCognitoIdentityProviderClient,
+        AdminDisableUserCommand: jest.fn(),
+        AdminDeleteUserCommand: jest.fn(),
+        mockSend, // Export mockSend to assert on tests
+    };
+});
+
+// must be imported before the handler
+const cognito = await import("@aws-sdk/client-cognito-identity-provider");
+const lambda = await import("@platelet-app/lambda");
+// import handler
+const { handler } = await import("./index.js");
+
+function setupFetchStub(data: any): () => Promise<Response> {
+    return function fetchStub(): Promise<Response> {
+        return new Promise((resolve) => {
+            resolve({
+                json: () =>
+                    Promise.resolve({
+                        data,
+                    }),
+            } as Response);
+        });
+    };
+}
+
+const fakeUser = {
+    getUser: {
+        id: "test",
+        _version: 10,
+        username: "some-username",
+        profilePicture: {
+            key: "some-key",
+            bucket: "some-bucket",
+        },
+    },
+};
+
+describe("RegisterTenant", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("empty test", () => {
+        expect(true).toBe(true);
+    });
+});

--- a/cdk/lib/lambda/node/RegisterTenant/src/index.test.ts
+++ b/cdk/lib/lambda/node/RegisterTenant/src/index.test.ts
@@ -3,10 +3,9 @@ import { jest, expect } from "@jest/globals";
 jest.unstable_mockModule("@platelet-app/lambda", () => ({
     request: jest.fn(),
     errorCheck: jest.fn(),
+    generateSecurePassword: jest.fn().mockReturnValue("some-password"),
     // @ts-ignore
-    getUserProfilePictures: jest.fn().mockResolvedValue({
-        Contents: [{ Key: "test-key" }, { Key: "test-key2" }],
-    }),
+    sendTenantWelcomeEmail: jest.fn().mockResolvedValue({}),
 }));
 
 jest.unstable_mockModule("@aws-sdk/client-cognito-identity-provider", () => {
@@ -17,8 +16,12 @@ jest.unstable_mockModule("@aws-sdk/client-cognito-identity-provider", () => {
     }));
     return {
         CognitoIdentityProviderClient: MockCognitoIdentityProviderClient,
-        AdminDisableUserCommand: jest.fn(),
+        AdminAddUserToGroupCommand: jest.fn(),
+        AdminCreateUserCommand: jest.fn(),
         AdminDeleteUserCommand: jest.fn(),
+        AdminUpdateUserAttributesCommand: jest.fn(),
+        DeliveryMediumType: { EMAIL: "EMAIL", SMS: "SMS" },
+        MessageActionType: { RESEND: "RESEND", SUPPRESS: "SUPPRESS" },
         mockSend, // Export mockSend to assert on tests
     };
 });

--- a/cdk/lib/lambda/node/RegisterTenant/src/index.test.ts
+++ b/cdk/lib/lambda/node/RegisterTenant/src/index.test.ts
@@ -1,34 +1,30 @@
 import { jest, expect } from "@jest/globals";
+import { mockClient } from "aws-sdk-client-mock";
+import {
+    CognitoIdentityProviderClient,
+    AdminAddUserToGroupCommand,
+    AdminCreateUserCommand,
+    AdminDeleteUserCommand,
+    AdminUpdateUserAttributesCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { mutations, queries } from "@platelet-app/graphql";
+
+// Create the mock instance
+const cognitoMock = mockClient(CognitoIdentityProviderClient);
 
 jest.unstable_mockModule("@platelet-app/lambda", () => ({
     request: jest.fn(),
     errorCheck: jest.fn(),
-    generateSecurePassword: jest.fn().mockReturnValue("some-password"),
-    // @ts-ignore
-    sendTenantWelcomeEmail: jest.fn().mockResolvedValue({}),
+    generateSecurePassword: jest.fn(() => "testGeneratedPassword"),
+    sendTenantWelcomeEmail: jest.fn(),
 }));
 
-jest.unstable_mockModule("@aws-sdk/client-cognito-identity-provider", () => {
-    // @ts-ignore
-    const mockSend = jest.fn().mockResolvedValue({});
-    const MockCognitoIdentityProviderClient = jest.fn(() => ({
-        send: mockSend,
-    }));
-    return {
-        CognitoIdentityProviderClient: MockCognitoIdentityProviderClient,
-        AdminAddUserToGroupCommand: jest.fn(),
-        AdminCreateUserCommand: jest.fn(),
-        AdminDeleteUserCommand: jest.fn(),
-        AdminUpdateUserAttributesCommand: jest.fn(),
-        DeliveryMediumType: { EMAIL: "EMAIL", SMS: "SMS" },
-        MessageActionType: { RESEND: "RESEND", SUPPRESS: "SUPPRESS" },
-        mockSend, // Export mockSend to assert on tests
-    };
-});
+jest.unstable_mockModule("uuid", () => ({
+    v4: jest.fn(() => "test-uuid"),
+}));
 
-// must be imported before the handler
-const cognito = await import("@aws-sdk/client-cognito-identity-provider");
 const lambda = await import("@platelet-app/lambda");
+
 // import handler
 const { handler } = await import("./index.js");
 
@@ -45,24 +41,303 @@ function setupFetchStub(data: any): () => Promise<Response> {
     };
 }
 
-const fakeUser = {
-    getUser: {
-        id: "test",
-        _version: 10,
-        username: "some-username",
-        profilePicture: {
-            key: "some-key",
-            bucket: "some-bucket",
+const GRAPHQL_ENDPOINT = "https://api.example.com/graphql";
+
+const fakeCreatedUser = {
+    createUser: {
+        id: "testUserId",
+        displayName: "New User",
+        name: "New User",
+        tenantId: "test-uuid",
+        cognitoId: "test-uuid",
+        username: "testUsername",
+        contact: {
+            emailAddress: "test@test.com",
         },
+        _version: 1,
     },
+};
+
+const fakeCreatedTenant = {
+    createTenant: {
+        id: "testTenantId",
+        name: "test tenant",
+    },
+};
+
+const fakeUpdatedUser = {
+    updateUser: {
+        id: "testUserId",
+        displayName: "New User",
+        name: "New User",
+        tenantId: "testTenantId",
+        cognitoId: "testSubId",
+        username: "testUsername",
+        contact: {
+            emailAddress: "test@test.com",
+        },
+        _version: 2,
+    },
+};
+
+const mockEvent = {
+    name: "New User",
+    emailAddress: "test@test.com",
+    tenantName: "test tenant",
 };
 
 describe("RegisterTenant", () => {
     beforeEach(() => {
+        cognitoMock.reset();
         jest.clearAllMocks();
     });
 
-    test("empty test", () => {
-        expect(true).toBe(true);
+    test("register a new tenant", async () => {
+        cognitoMock.on(AdminCreateUserCommand).resolves({
+            User: {
+                Attributes: [
+                    {
+                        Name: "sub",
+                        Value: "testSubId",
+                    },
+                ],
+            },
+        });
+
+        lambda.request
+            .mockImplementationOnce(setupFetchStub(fakeCreatedUser))
+            .mockImplementationOnce(setupFetchStub(fakeCreatedTenant))
+            .mockImplementationOnce(setupFetchStub(fakeUpdatedUser));
+
+        const result = await handler(mockEvent);
+
+        expect(lambda.request).toHaveBeenCalledTimes(3);
+        expect(lambda.request).toHaveBeenNthCalledWith(
+            1,
+            {
+                query: mutations.createUser,
+                variables: {
+                    input: {
+                        tenantId: "test-uuid",
+                        disabled: 0,
+                        isPrimaryAdmin: 1,
+                        cognitoId: "test-uuid",
+                        username: "test-uuid",
+                        name: mockEvent.name,
+                        displayName: mockEvent.name,
+                        roles: ["USER", "ADMIN", "COORDINATOR"],
+                        contact: { emailAddress: mockEvent.emailAddress },
+                    },
+                },
+            },
+            GRAPHQL_ENDPOINT
+        );
+        expect(lambda.request).toHaveBeenNthCalledWith(
+            2,
+            {
+                query: mutations.createTenant,
+                variables: {
+                    input: {
+                        name: mockEvent.tenantName,
+                        tenantAdminId: "testUserId",
+                        referenceIdentifier: "test",
+                    },
+                },
+            },
+            GRAPHQL_ENDPOINT
+        );
+        expect(lambda.request).toHaveBeenNthCalledWith(
+            3,
+            {
+                query: mutations.updateUser,
+                variables: {
+                    input: {
+                        id: "testUserId",
+                        tenantId: "testTenantId",
+                        cognitoId: "testSubId",
+                        _version: 1,
+                    },
+                },
+            },
+            GRAPHQL_ENDPOINT
+        );
+
+        const createUserCalls = cognitoMock.commandCalls(
+            AdminCreateUserCommand
+        );
+        expect(createUserCalls).toHaveLength(1);
+        expect(createUserCalls[0].args[0].input).toEqual({
+            DesiredDeliveryMediums: ["EMAIL"],
+            ForceAliasCreation: false,
+            UserAttributes: [
+                {
+                    Name: "email",
+                    Value: mockEvent.emailAddress,
+                },
+                {
+                    Name: "email_verified",
+                    Value: "true",
+                },
+            ],
+            TemporaryPassword: "testGeneratedPassword",
+            UserPoolId: "some_pool",
+            Username: "testUsername",
+            MessageAction: "SUPPRESS",
+        });
+
+        const updateAttributesCalls = cognitoMock.commandCalls(
+            AdminUpdateUserAttributesCommand
+        );
+        expect(updateAttributesCalls).toHaveLength(1);
+        expect(updateAttributesCalls[0].args[0].input).toEqual({
+            UserAttributes: [
+                {
+                    Name: "email",
+                    Value: mockEvent.emailAddress,
+                },
+                {
+                    Name: "email_verified",
+                    Value: "true",
+                },
+            ],
+            UserPoolId: "some_pool",
+            Username: "testUsername",
+        });
+
+        const addToGroupCalls = cognitoMock.commandCalls(
+            AdminAddUserToGroupCommand
+        );
+        expect(addToGroupCalls.map((call) => call.args[0].input)).toEqual(
+            ["USER", "ADMIN", "COORDINATOR"].map((group) => ({
+                GroupName: group,
+                UserPoolId: "some_pool",
+                Username: "test-uuid",
+            }))
+        );
+
+        expect(lambda.sendTenantWelcomeEmail).toHaveBeenCalledWith(
+            mockEvent.emailAddress,
+            mockEvent.name,
+            "testGeneratedPassword"
+        );
+
+        expect(result).toEqual({
+            id: "testTenantId",
+            name: mockEvent.tenantName,
+            admin: fakeUpdatedUser.updateUser,
+        });
+    });
+
+    test("clean up on failure", async () => {
+        cognitoMock.on(AdminCreateUserCommand).resolves({
+            User: {
+                Attributes: [
+                    {
+                        Name: "sub",
+                        Value: "testSubId",
+                    },
+                ],
+            },
+        });
+
+        lambda.request
+            .mockImplementationOnce(setupFetchStub(fakeCreatedUser))
+            .mockImplementationOnce(setupFetchStub(fakeCreatedTenant))
+            .mockImplementationOnce(() =>
+                Promise.reject(new Error("test error"))
+            )
+            .mockImplementationOnce(
+                setupFetchStub({
+                    getUser: { id: "deleteUserId", _version: 5 },
+                })
+            )
+            .mockImplementationOnce(setupFetchStub({}))
+            .mockImplementationOnce(
+                setupFetchStub({
+                    getTenant: { id: "deleteTenantId", _version: 6 },
+                })
+            )
+            .mockImplementation(setupFetchStub({}));
+
+        await expect(handler(mockEvent)).rejects.toThrow("test error");
+
+        const deleteUserCalls = cognitoMock.commandCalls(
+            AdminDeleteUserCommand
+        );
+        expect(deleteUserCalls).toHaveLength(1);
+        expect(deleteUserCalls[0].args[0].input).toEqual({
+            UserPoolId: "some_pool",
+            Username: "testUsername",
+        });
+
+        expect(lambda.request).toHaveBeenCalledWith(
+            {
+                query: queries.getUser,
+                variables: { id: "testUserId" },
+            },
+            GRAPHQL_ENDPOINT
+        );
+        expect(lambda.request).toHaveBeenCalledWith(
+            {
+                query: mutations.deleteUser,
+                variables: { input: { id: "deleteUserId", _version: 5 } },
+            },
+            GRAPHQL_ENDPOINT
+        );
+        expect(lambda.request).toHaveBeenCalledWith(
+            {
+                query: queries.getTenant,
+                variables: { id: "testTenantId" },
+            },
+            GRAPHQL_ENDPOINT
+        );
+        expect(lambda.request).toHaveBeenCalledWith(
+            {
+                query: mutations.deleteTenant,
+                variables: { input: { id: "deleteTenantId", _version: 6 } },
+            },
+            GRAPHQL_ENDPOINT
+        );
+    });
+
+    test("clean up the user when the tenant name is too short", async () => {
+        lambda.request
+            .mockImplementationOnce(setupFetchStub(fakeCreatedUser))
+            .mockImplementationOnce(
+                setupFetchStub({
+                    getUser: { id: "deleteUserId", _version: 5 },
+                })
+            )
+            .mockImplementation(setupFetchStub({}));
+
+        await expect(
+            handler({ ...mockEvent, tenantName: "a b" })
+        ).rejects.toThrow(
+            "tenantName must be at least 4 characters without whitespace"
+        );
+
+        // the cognito user was never created so it should not be deleted
+        expect(cognitoMock.commandCalls(AdminCreateUserCommand)).toHaveLength(
+            0
+        );
+        expect(cognitoMock.commandCalls(AdminDeleteUserCommand)).toHaveLength(
+            0
+        );
+
+        expect(lambda.request).toHaveBeenCalledWith(
+            {
+                query: mutations.deleteUser,
+                variables: { input: { id: "deleteUserId", _version: 5 } },
+            },
+            GRAPHQL_ENDPOINT
+        );
+        // no tenant was created so there is nothing to look up or delete
+        expect(lambda.request).not.toHaveBeenCalledWith(
+            {
+                query: queries.getTenant,
+                variables: { id: expect.any(String) },
+            },
+            GRAPHQL_ENDPOINT
+        );
     });
 });

--- a/cdk/lib/lambda/node/RegisterTenant/src/index.ts
+++ b/cdk/lib/lambda/node/RegisterTenant/src/index.ts
@@ -1,0 +1,318 @@
+import type { LambdaEvent } from "./interfaces.js";
+import type { CreateTenantMutation, Tenant } from "@platelet-app/types";
+import * as uuid from "uuid";
+import {
+    request,
+    errorCheck,
+    generateSecurePassword,
+    sendTenantWelcomeEmail,
+} from "@platelet-app/lambda";
+import { getUser } from "./queries.js";
+import { mutations, queries } from "@platelet-app/graphql";
+import type { User } from "@platelet-app/types";
+import {
+    AdminAddUserToGroupCommand,
+    AdminCreateUserCommand,
+    AdminDeleteUserCommand,
+    AdminUpdateUserAttributesCommand,
+    CognitoIdentityProviderClient,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+const GRAPHQL_ENDPOINT = process.env.GRAPHQL_ENDPOINT || "";
+const USER_POOL_ID = process.env.USER_POOL_ID;
+const REGION = process.env.REGION;
+
+const config = { region: REGION || "" };
+const cognitoClient = new CognitoIdentityProviderClient(config);
+
+const generateReferenceIdentifier = (tenantName: string) => {
+    if (!tenantName) {
+        throw new Error(`tenantName is required`);
+    }
+    // strip all non-alphanumeric characters
+    tenantName = tenantName.replace(/[^a-zA-Z0-9]/g, "");
+    if (tenantName.length < 4) {
+        throw new Error(
+            `tenantName must be at least 4 characters without whitespace`
+        );
+    }
+    return tenantName.substring(0, 4);
+};
+
+const addUserToCognito = async (user: User) => {
+    const generatedPassword = generateSecurePassword();
+    const params = {
+        DesiredDeliveryMediums: ["EMAIL"],
+        ForceAliasCreation: false,
+        UserAttributes: [
+            {
+                Name: "email",
+                Value: user.contact?.emailAddress || "",
+            },
+            {
+                Name: "email_verified",
+                Value: "true",
+            },
+        ],
+        TemporaryPassword: generatedPassword,
+        UserPoolId: USER_POOL_ID,
+        Username: user.username,
+        MessageAction: "SUPPRESS",
+    };
+
+    const command = new AdminCreateUserCommand(params);
+
+    const cognitoResp = await cognitoClient.send(command);
+
+    console.log("Cognito response:", cognitoResp?.User?.Attributes);
+
+    if (!cognitoResp.User) {
+        throw new Error(
+            `Failure to create new user with email ${user?.contact?.emailAddress}`
+        );
+    }
+    const subFind = cognitoResp?.User?.Attributes?.find(
+        (attr) => attr.Name === "sub"
+    );
+    if (!subFind) {
+        throw new Error(`missing sub attribute for newly created user`);
+    }
+    const cognitoId = subFind.Value;
+    if (!cognitoId) {
+        throw new Error(`missing cognitoId attribute for newly created user`);
+    }
+
+    return {
+        password: generatedPassword,
+        sub: subFind.Value,
+        username: user.username,
+    };
+};
+
+const setUserRoles = async (username: string) => {
+    console.log("Amending roles for:", username);
+    for (const role of ["USER", "ADMIN", "COORDINATOR"]) {
+        const params = {
+            GroupName: role,
+            UserPoolId: USER_POOL_ID,
+            Username: username,
+        };
+        const command = new AdminAddUserToGroupCommand(params);
+        await cognitoClient.send(command);
+    }
+};
+
+const createNewAdminUser = async (newUser: {
+    name: string;
+    displayName: string;
+    emailAddress: string;
+    username: string;
+}) => {
+    const tenantId = uuid.v4();
+
+    let { name, displayName, emailAddress, username } = newUser;
+    const createUserInput = {
+        tenantId: tenantId,
+        disabled: 0,
+        isPrimaryAdmin: 1,
+        cognitoId: uuid.v4(),
+        username,
+        name,
+        displayName,
+        roles: ["USER", "ADMIN", "COORDINATOR"],
+        contact: { emailAddress },
+    };
+
+    const createdUserResponse = await request(
+        {
+            query: mutations.createUser,
+            variables: { input: createUserInput },
+        },
+        GRAPHQL_ENDPOINT
+    );
+    const result = await createdUserResponse.json();
+    errorCheck(result);
+    return result.data.createUser;
+};
+
+async function updateUserTenantAndCognito(
+    user?: User,
+    tenantId?: string,
+    cognitoId?: string
+) {
+    if (!user || !user._version || !user.id || !tenantId || !cognitoId) {
+        throw new Error(`user, _version, tenantId, and cognitoId are required`);
+    }
+    const params = {
+        UserAttributes: [
+            {
+                Name: "email",
+                Value: user?.contact?.emailAddress || "",
+            },
+            {
+                Name: "email_verified",
+                Value: "true",
+            },
+        ],
+        UserPoolId: USER_POOL_ID,
+        Username: user.username,
+    };
+    const command = new AdminUpdateUserAttributesCommand(params);
+    await cognitoClient.send(command);
+
+    const updateUserInput = {
+        id: user.id,
+        tenantId: tenantId,
+        cognitoId: cognitoId,
+        _version: user._version,
+    };
+
+    const userResult = await request(
+        {
+            query: mutations.updateUser,
+            variables: { input: updateUserInput },
+        },
+        GRAPHQL_ENDPOINT
+    );
+    const result = await userResult.json();
+    errorCheck(result);
+    return result.data.updateUser;
+}
+
+const cleanUp = async (
+    user: User,
+    tenant: Tenant,
+    cognitoUser?: { username: string }
+) => {
+    console.log("Cleaning up user and tenant");
+    if (cognitoUser) {
+        console.log("Deleting cognito user:", cognitoUser.username);
+        const params = {
+            UserPoolId: USER_POOL_ID,
+            Username: user.username,
+        };
+        const command = new AdminDeleteUserCommand(params);
+        await cognitoClient.send(command);
+    }
+    if (user) {
+        console.log("Deleting user:", user.id);
+        const existingUser = await request(
+            {
+                query: getUser,
+                variables: { id: user.id },
+            },
+
+            GRAPHQL_ENDPOINT
+        );
+        const result = await existingUser.json();
+        if (result?.data?.getUser) {
+            const { id, _version } = result.data.getUser;
+            console.log("User id:", id, "version:", _version);
+            await request(
+                {
+                    query: mutations.deleteUser,
+                    variables: {
+                        input: {
+                            id,
+                            _version,
+                        },
+                    },
+                },
+                GRAPHQL_ENDPOINT
+            );
+        } else {
+            console.warn("User to clean up was not found");
+        }
+    }
+    if (tenant) {
+        console.log("Deleting tenant:", tenant.id);
+        const existingTenant = await request(
+            {
+                query: queries.getTenant,
+                variables: { id: tenant.id },
+            },
+
+            GRAPHQL_ENDPOINT
+        );
+        const result = await existingTenant.json();
+        if (result?.data?.getTenant) {
+            const { id, _version } = result.data.getTenant;
+            console.log("Tenant id:", id, "version:", _version);
+            await request(
+                {
+                    query: mutations.deleteTenant,
+                    variables: {
+                        input: {
+                            id,
+                            _version,
+                        },
+                    },
+                },
+                GRAPHQL_ENDPOINT
+            );
+        } else {
+            console.warn("Tenant to clean up was not found");
+        }
+    }
+};
+
+const addTenant = async (tenant: { name: string; tenantAdminId: string }) => {
+    const referenceIdentifier = generateReferenceIdentifier(tenant.name);
+    const createdTenantResult = await request(
+        {
+            query: mutations.createTenant,
+            variables: { input: { ...tenant, referenceIdentifier } },
+        },
+        GRAPHQL_ENDPOINT
+    );
+    const createdTenant = await createdTenantResult.json();
+    errorCheck(createdTenant);
+    return createdTenant?.data?.createTenant;
+};
+
+export const handler = async (
+    event: LambdaEvent
+): Promise<CreateTenantMutation> => {
+    console.log("register tenant", event);
+    if (!GRAPHQL_ENDPOINT) {
+        throw new Error("Missing env variables");
+    }
+    const user = {
+        name: event.name,
+        displayName: event.name,
+        emailAddress: event.emailAddress,
+        roles: ["USER", "ADMIN", "COORDINATOR"],
+        username: uuid.v4(),
+    };
+    const tenant = {
+        name: event.tenantName,
+    };
+    let newUser, newTenant, cognitoUser;
+    try {
+        newUser = await createNewAdminUser(user);
+        newTenant = await addTenant({
+            ...tenant,
+            tenantAdminId: newUser.id,
+        });
+        cognitoUser = await addUserToCognito(newUser);
+        const admin = await updateUserTenantAndCognito(
+            newUser,
+            newTenant.id,
+            cognitoUser.sub
+        );
+        await setUserRoles(user.username);
+        console.log("Tenant result:", newTenant);
+        console.log("User result:", newUser);
+        await sendTenantWelcomeEmail(
+            event.emailAddress,
+            event.name,
+            cognitoUser.password
+        );
+        console.log("Successfully sent welcome email");
+        return { ...newTenant, admin };
+    } catch (e) {
+        console.error("Error:", e);
+        await cleanUp(newUser, newTenant, cognitoUser);
+        throw e;
+    }
+};

--- a/cdk/lib/lambda/node/RegisterTenant/src/index.ts
+++ b/cdk/lib/lambda/node/RegisterTenant/src/index.ts
@@ -7,7 +7,6 @@ import {
     generateSecurePassword,
     sendTenantWelcomeEmail,
 } from "@platelet-app/lambda";
-import { getUser } from "./queries.js";
 import { mutations, queries } from "@platelet-app/graphql";
 import type { User } from "@platelet-app/types";
 import {
@@ -200,7 +199,7 @@ const cleanUp = async (
         console.log("Deleting user:", user.id);
         const existingUser = await request(
             {
-                query: getUser,
+                query: queries.getUser,
                 variables: { id: user.id },
             },
 

--- a/cdk/lib/lambda/node/RegisterTenant/src/index.ts
+++ b/cdk/lib/lambda/node/RegisterTenant/src/index.ts
@@ -16,6 +16,8 @@ import {
     AdminDeleteUserCommand,
     AdminUpdateUserAttributesCommand,
     CognitoIdentityProviderClient,
+    DeliveryMediumType,
+    MessageActionType,
 } from "@aws-sdk/client-cognito-identity-provider";
 
 const GRAPHQL_ENDPOINT = process.env.GRAPHQL_ENDPOINT || "";
@@ -42,7 +44,7 @@ const generateReferenceIdentifier = (tenantName: string) => {
 const addUserToCognito = async (user: User) => {
     const generatedPassword = generateSecurePassword();
     const params = {
-        DesiredDeliveryMediums: ["EMAIL"],
+        DesiredDeliveryMediums: [DeliveryMediumType.EMAIL],
         ForceAliasCreation: false,
         UserAttributes: [
             {
@@ -57,7 +59,7 @@ const addUserToCognito = async (user: User) => {
         TemporaryPassword: generatedPassword,
         UserPoolId: USER_POOL_ID,
         Username: user.username,
-        MessageAction: "SUPPRESS",
+        MessageAction: MessageActionType.SUPPRESS,
     };
 
     const command = new AdminCreateUserCommand(params);

--- a/cdk/lib/lambda/node/RegisterTenant/src/interfaces.ts
+++ b/cdk/lib/lambda/node/RegisterTenant/src/interfaces.ts
@@ -1,0 +1,5 @@
+export interface LambdaEvent {
+    name: string;
+    emailAddress: string;
+    tenantName: string;
+}

--- a/cdk/lib/lambda/node/RegisterTenant/tsconfig.json
+++ b/cdk/lib/lambda/node/RegisterTenant/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "module": "nodenext",
+    "target": "esnext",
+    "types": [],
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "strict": true,
+    "jsx": "react-jsx",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true,
+  },
+
+  "include": [
+      "src/**/*"
+  ],
+  "exclude": [
+      "node_modules",
+      "**/*.spec.ts",
+      "**/*.d.ts",
+      "src/*.test.ts"
+  ]
+}

--- a/cdk/lib/lambda/node/package.json
+++ b/cdk/lib/lambda/node/package.json
@@ -17,6 +17,7 @@
         "build-get-take-out-possible-rider-responsibilities": "cd GetTakeOutPossibleRiderResponsibilities && npm run build",
         "build-send-take-out-data": "cd SendTakeOutData && npm run build",
         "build-delete-user-on-failure": "cd DeleteUserOnFailure && npm run build",
+        "build-register-tenant": "cd RegisterTenant && npm run build",
         "package": "npm-run-all pk-*",
         "pk-get-user-comments": "cd GetUserComments && npm run package",
         "pk-get-user-assignments": "cd GetUserAssignments && npm run package",
@@ -30,7 +31,8 @@
         "pk-get-take-out-user-assignments": "cd GetTakeOutUserAssignments && npm run package",
         "pk-get-take-out-possible-rider-responsibilities": "cd GetTakeOutPossibleRiderResponsibilities && npm run package",
         "pk-send-take-out-data": "cd SendTakeOutData && npm run package",
-        "pk-delete-user-on-failure": "cd DeleteUserOnFailure && npm run package"
+        "pk-delete-user-on-failure": "cd DeleteUserOnFailure && npm run package",
+        "pk-register-tenant": "cd RegisterTenant && npm run package"
     },
     "keywords": [],
     "author": "",

--- a/cdk/lib/platelet-cdk-stack.ts
+++ b/cdk/lib/platelet-cdk-stack.ts
@@ -90,6 +90,7 @@ export class PlateletCdkStack extends cdk.Stack {
             graphQLEndpoint,
             userPoolId,
             graphqlAppSync,
+            userPoolArn: userPool.userPoolArn,
         });
 
         if (this.node.tryGetContext("createCypressTestingRole") === "true") {

--- a/cdk/lib/platelet-cdk-stack.ts
+++ b/cdk/lib/platelet-cdk-stack.ts
@@ -91,6 +91,10 @@ export class PlateletCdkStack extends cdk.Stack {
             userPoolId,
             graphqlAppSync,
             userPoolArn: userPool.userPoolArn,
+            fromEmailParameterArn: SSMParamsConstructInstance.fromEmailArn,
+            domainNameParameterArn: SSMParamsConstructInstance.domainNameArn,
+            amplifyEnv,
+            sesIdentity: SES,
         });
 
         if (this.node.tryGetContext("createCypressTestingRole") === "true") {

--- a/cdk/lib/platelet-cdk-stack.ts
+++ b/cdk/lib/platelet-cdk-stack.ts
@@ -1,4 +1,5 @@
 import * as cdk from "aws-cdk-lib";
+import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as ses from "aws-cdk-lib/aws-ses";
 import { Construct } from "constructs";
@@ -7,6 +8,7 @@ import { RetryFunctionConstruct } from "./retry-function-construct";
 import { UserTakeOutDataStepFunction } from "./user-take-out-data-step-function-construct";
 import { CypressTestRole } from "./cypress-test-role-construct";
 import { SSMParamsConstruct } from "./ssm-params-construct";
+import { RegisterTenantFunctionConstruct } from "./register-tenant-function-construct";
 
 export class PlateletCdkStack extends cdk.Stack {
     constructor(scope: Construct, id: string, props: cdk.StackProps) {
@@ -55,6 +57,12 @@ export class PlateletCdkStack extends cdk.Stack {
             }
         );
 
+        const graphqlAppSync = appsync.GraphqlApi.fromGraphqlApiAttributes(
+            this,
+            "GraphqlAppSync",
+            { graphqlApiId: appsyncId }
+        );
+
         new DeleteUserStepFunction(this, "DeleteUserStepFunction", {
             appsyncId,
             userPoolId,
@@ -75,6 +83,13 @@ export class PlateletCdkStack extends cdk.Stack {
             alertEmail,
             fromEmailParameterArn: SSMParamsConstructInstance.fromEmailArn,
             sesIdentity: SES,
+        });
+
+        new RegisterTenantFunctionConstruct(this, "RegisterTenantFunction", {
+            region: this.region,
+            graphQLEndpoint,
+            userPoolId,
+            graphqlAppSync,
         });
 
         if (this.node.tryGetContext("createCypressTestingRole") === "true") {

--- a/cdk/lib/register-tenant-function-construct.ts
+++ b/cdk/lib/register-tenant-function-construct.ts
@@ -9,6 +9,7 @@ export interface RegisterTenantFunctionConstructProps {
     graphQLEndpoint: string;
     userPoolId: string;
     graphqlAppSync: cdk.aws_appsync.IGraphqlApi;
+    userPoolArn: string;
 }
 
 export class RegisterTenantFunctionConstruct extends Construct {
@@ -18,6 +19,10 @@ export class RegisterTenantFunctionConstruct extends Construct {
         props: RegisterTenantFunctionConstructProps
     ) {
         super(scope, id);
+
+        const role = new iam.Role(this, "RegisterTenantFunctionRole", {
+            assumedBy: new iam.AccountPrincipal(cdk.Stack.of(this).account),
+        });
 
         const registerTenantFunction = new lambda.Function(
             this,
@@ -54,6 +59,17 @@ export class RegisterTenantFunctionConstruct extends Construct {
                     "deleteTenant",
                 ],
             }
+        );
+        role.addToPolicy(
+            new iam.PolicyStatement({
+                actions: [
+                    "cognito-idp:AdminCreateUser",
+                    "cognito-idp:AdminDeleteUser",
+                    "cognito-idp:AdminAddUserToGroup",
+                    "cognito-idp:AdminUpdateUserAttributes",
+                ],
+                resources: [props.userPoolArn],
+            })
         );
     }
 }

--- a/cdk/lib/register-tenant-function-construct.ts
+++ b/cdk/lib/register-tenant-function-construct.ts
@@ -21,7 +21,7 @@ export class RegisterTenantFunctionConstruct extends Construct {
         super(scope, id);
 
         const role = new iam.Role(this, "RegisterTenantFunctionRole", {
-            assumedBy: new iam.AccountPrincipal(cdk.Stack.of(this).account),
+            assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
         });
 
         const registerTenantFunction = new lambda.Function(
@@ -39,9 +39,7 @@ export class RegisterTenantFunctionConstruct extends Construct {
                     GRAPHQL_ENDPOINT: props.graphQLEndpoint,
                     USER_POOL_ID: props.userPoolId,
                 },
-                role: new iam.Role(this, "RegisterTenantFunctionRole", {
-                    assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
-                }),
+                role,
             }
         );
         new cdk.CfnOutput(this, "AdminRoleNamesRegisterTenant", {

--- a/cdk/lib/register-tenant-function-construct.ts
+++ b/cdk/lib/register-tenant-function-construct.ts
@@ -84,7 +84,10 @@ export class RegisterTenantFunctionConstruct extends Construct {
         role.addToPolicy(
             new iam.PolicyStatement({
                 actions: ["ssm:GetParameter"],
-                resources: [props.fromEmailParameterArn],
+                resources: [
+                    props.fromEmailParameterArn,
+                    props.domainNameParameterArn,
+                ],
             })
         );
     }

--- a/cdk/lib/register-tenant-function-construct.ts
+++ b/cdk/lib/register-tenant-function-construct.ts
@@ -1,0 +1,59 @@
+import { Construct } from "constructs";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as cdk from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { createLambdaStatement, getRoleArnNameOnly } from "./utils";
+
+export interface RegisterTenantFunctionConstructProps {
+    region: string;
+    graphQLEndpoint: string;
+    userPoolId: string;
+    graphqlAppSync: cdk.aws_appsync.IGraphqlApi;
+}
+
+export class RegisterTenantFunctionConstruct extends Construct {
+    constructor(
+        scope: Construct,
+        id: string,
+        props: RegisterTenantFunctionConstructProps
+    ) {
+        super(scope, id);
+
+        const registerTenantFunction = new lambda.Function(
+            this,
+            "RegisterTenantFunction",
+            {
+                runtime: lambda.Runtime.NODEJS_22_X,
+                handler: "index.handler",
+                code: lambda.Code.fromAsset(
+                    "./lib/lambda/node/RegisterTenant/dist"
+                ),
+                timeout: cdk.Duration.seconds(180),
+                environment: {
+                    REGION: props.region,
+                    GRAPHQL_ENDPOINT: props.graphQLEndpoint,
+                    USER_POOL_ID: props.userPoolId,
+                },
+                role: new iam.Role(this, "RegisterTenantFunctionRole", {
+                    assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+                }),
+            }
+        );
+        new cdk.CfnOutput(this, "AdminRoleNamesRegisterTenant", {
+            value: getRoleArnNameOnly(registerTenantFunction),
+        });
+        createLambdaStatement(
+            registerTenantFunction,
+            props.graphqlAppSync.arn,
+            {
+                queries: ["getTenant"],
+                mutations: [
+                    "createUser",
+                    "updateUser",
+                    "createTenant",
+                    "deleteTenant",
+                ],
+            }
+        );
+    }
+}

--- a/cdk/lib/register-tenant-function-construct.ts
+++ b/cdk/lib/register-tenant-function-construct.ts
@@ -10,6 +10,10 @@ export interface RegisterTenantFunctionConstructProps {
     userPoolId: string;
     graphqlAppSync: cdk.aws_appsync.IGraphqlApi;
     userPoolArn: string;
+    fromEmailParameterArn: string;
+    domainNameParameterArn: string;
+    amplifyEnv: string;
+    sesIdentity: cdk.aws_ses.IEmailIdentity;
 }
 
 export class RegisterTenantFunctionConstruct extends Construct {
@@ -38,6 +42,7 @@ export class RegisterTenantFunctionConstruct extends Construct {
                     REGION: props.region,
                     GRAPHQL_ENDPOINT: props.graphQLEndpoint,
                     USER_POOL_ID: props.userPoolId,
+                    ENV: props.amplifyEnv,
                 },
                 role,
             }
@@ -67,6 +72,19 @@ export class RegisterTenantFunctionConstruct extends Construct {
                     "cognito-idp:AdminUpdateUserAttributes",
                 ],
                 resources: [props.userPoolArn],
+            })
+        );
+        role.addToPolicy(
+            new iam.PolicyStatement({
+                actions: ["ses:SendRawEmail", "ses:SendEmail"],
+                resources: [props.sesIdentity.emailIdentityArn],
+            })
+        );
+
+        role.addToPolicy(
+            new iam.PolicyStatement({
+                actions: ["ssm:GetParameter"],
+                resources: [props.fromEmailParameterArn],
             })
         );
     }

--- a/cdk/lib/ssm-params-construct.ts
+++ b/cdk/lib/ssm-params-construct.ts
@@ -10,6 +10,7 @@ export interface SSMParamsConstructProps {
 
 export class SSMParamsConstruct extends Construct {
     public fromEmailArn: string;
+    public domainNameArn: string;
     constructor(scope: Construct, id: string, props: SSMParamsConstructProps) {
         super(scope, id);
 
@@ -31,6 +32,7 @@ export class SSMParamsConstruct extends Construct {
         );
 
         this.fromEmailArn = fromEmailParam.parameterArn;
+        this.domainNameArn = domainNameParam.parameterArn;
 
         // output values to be used in custom-policies.json files
         new cdk.CfnOutput(this, "FromEmailSSMParamArnOutput", {
@@ -39,6 +41,5 @@ export class SSMParamsConstruct extends Construct {
         new cdk.CfnOutput(this, "DomainNameSSMParamArnOutput", {
             value: domainNameParam.parameterArn,
         });
-
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -687,12 +687,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@aws-crypto/ie11-detection": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
@@ -790,12 +784,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "1.2.2",
@@ -1779,13 +1767,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "license": "0BSD"
-        },
         "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -2641,11 +2622,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-lex-runtime-service/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-        },
         "node_modules/@aws-sdk/client-lex-runtime-service/node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -3357,11 +3333,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-lex-runtime-v2/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-        },
         "node_modules/@aws-sdk/client-lex-runtime-v2/node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -4016,11 +3987,6 @@
             "engines": {
                 "node": ">= 12.0.0"
             }
-        },
-        "node_modules/@aws-sdk/client-location/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
         },
         "node_modules/@aws-sdk/client-location/node_modules/uuid": {
             "version": "8.3.2",
@@ -4756,11 +4722,277 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-ses/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
+        "node_modules/@aws-sdk/client-ssm": {
+            "version": "3.1106.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1106.0.tgz",
+            "integrity": "sha512-jPGMnYT+XtpXnnXzOBm9zBg+o4+vGQClj8TtDKZzX6sGFVcEunQEL1dZHn5iRy3z5vaGN+T7ch4zgI9A2WJkfA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/credential-provider-node": "^3.972.78",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/core": {
+            "version": "3.977.6",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+            "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.974.2",
+                "@aws-sdk/xml-builder": "^3.972.37",
+                "@aws/lambda-invoke-store": "^0.3.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/signature-v4": "^5.6.12",
+                "@smithy/types": "^4.16.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.972.67",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+            "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.972.69",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+            "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.973.12",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+            "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/credential-provider-env": "^3.972.67",
+                "@aws-sdk/credential-provider-http": "^3.972.69",
+                "@aws-sdk/credential-provider-login": "^3.972.74",
+                "@aws-sdk/credential-provider-process": "^3.972.67",
+                "@aws-sdk/credential-provider-sso": "^3.973.11",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/credential-provider-imds": "^4.4.16",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-login": {
+            "version": "3.972.74",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+            "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.972.78",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+            "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "^3.972.67",
+                "@aws-sdk/credential-provider-http": "^3.972.69",
+                "@aws-sdk/credential-provider-ini": "^3.973.12",
+                "@aws-sdk/credential-provider-process": "^3.972.67",
+                "@aws-sdk/credential-provider-sso": "^3.973.11",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/credential-provider-imds": "^4.4.16",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.972.67",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+            "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.973.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+            "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/token-providers": "3.1103.0",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.972.73",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+            "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/nested-clients": {
+            "version": "3.997.41",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+            "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.996.43",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+            "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/signature-v4": "^5.6.12",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/token-providers": {
+            "version": "3.1103.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+            "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/nested-clients": "^3.997.41",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/types": {
+            "version": "3.974.2",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+            "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.37",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+            "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ssm/node_modules/@aws/lambda-invoke-store": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+            "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
+            }
         },
         "node_modules/@aws-sdk/client-sso": {
             "version": "3.186.0",
@@ -5309,11 +5541,6 @@
             "engines": {
                 "node": ">= 12.0.0"
             }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
         },
         "node_modules/@aws-sdk/client-sso/node_modules/uuid": {
             "version": "8.3.2",
@@ -5984,11 +6211,6 @@
                 "url": "https://paypal.me/naturalintelligence"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-        },
         "node_modules/@aws-sdk/client-sts/node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -6218,12 +6440,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/@aws-sdk/core/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@aws-sdk/credential-provider-cognito-identity": {
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.6.1.tgz",
@@ -6295,12 +6511,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@aws-sdk/credential-provider-imds": {
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
@@ -6369,12 +6579,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@aws-sdk/credential-provider-login/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@aws-sdk/credential-provider-node": {
             "version": "3.6.1",
@@ -6466,11 +6670,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-        },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
             "version": "3.186.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.186.0.tgz",
@@ -6504,11 +6703,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-        },
         "node_modules/@aws-sdk/eventstream-codec": {
             "version": "3.186.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.186.0.tgz",
@@ -6539,11 +6733,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/eventstream-codec/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-        },
         "node_modules/@aws-sdk/eventstream-handler-node": {
             "version": "3.186.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.186.0.tgz",
@@ -6564,11 +6753,6 @@
             "engines": {
                 "node": ">= 12.0.0"
             }
-        },
-        "node_modules/@aws-sdk/eventstream-handler-node/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
         },
         "node_modules/@aws-sdk/eventstream-marshaller": {
             "version": "3.6.1",
@@ -6871,11 +7055,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-eventstream/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-        },
         "node_modules/@aws-sdk/middleware-expect-continue": {
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.6.1.tgz",
@@ -7063,12 +7242,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@aws-sdk/middleware-header-default": {
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.6.1.tgz",
@@ -7171,11 +7344,6 @@
             "engines": {
                 "node": ">= 12.0.0"
             }
-        },
-        "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
         },
         "node_modules/@aws-sdk/middleware-retry": {
             "version": "3.6.1",
@@ -7338,11 +7506,6 @@
             "engines": {
                 "node": ">= 12.0.0"
             }
-        },
-        "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
         },
         "node_modules/@aws-sdk/middleware-serde": {
             "version": "3.6.1",
@@ -7692,12 +7855,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/nested-clients/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@aws-sdk/node-config-provider": {
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.6.1.tgz",
@@ -7834,12 +7991,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@aws-sdk/region-config-resolver/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@aws-sdk/s3-request-presigner": {
             "version": "3.6.1",
@@ -8037,12 +8188,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -8096,12 +8241,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@aws-sdk/types": {
             "version": "3.6.1",
@@ -8248,11 +8387,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/util-config-provider/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-        },
         "node_modules/@aws-sdk/util-create-request": {
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.6.1.tgz",
@@ -8305,11 +8439,6 @@
             "engines": {
                 "node": ">= 12.0.0"
             }
-        },
-        "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
         },
         "node_modules/@aws-sdk/util-defaults-mode-node": {
             "version": "3.186.0",
@@ -8474,11 +8603,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-        },
         "node_modules/@aws-sdk/util-endpoints": {
             "version": "3.936.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
@@ -8507,12 +8631,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@aws-sdk/util-format-url": {
             "version": "3.6.1",
@@ -8559,11 +8677,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        },
         "node_modules/@aws-sdk/util-middleware": {
             "version": "3.186.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.186.0.tgz",
@@ -8574,11 +8687,6 @@
             "engines": {
                 "node": ">= 12.0.0"
             }
-        },
-        "node_modules/@aws-sdk/util-middleware/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
         },
         "node_modules/@aws-sdk/util-uri-escape": {
             "version": "3.6.1",
@@ -11466,14 +11574,6 @@
                 "tslib": "^2.4.0"
             }
         },
-        "node_modules/@emnapi/core/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "license": "0BSD",
-            "optional": true
-        },
         "node_modules/@emnapi/runtime": {
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
@@ -11485,14 +11585,6 @@
                 "tslib": "^2.4.0"
             }
         },
-        "node_modules/@emnapi/runtime/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "license": "0BSD",
-            "optional": true
-        },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
@@ -11503,14 +11595,6 @@
             "dependencies": {
                 "tslib": "^2.4.0"
             }
-        },
-        "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "license": "0BSD",
-            "optional": true
         },
         "node_modules/@emotion/babel-plugin": {
             "version": "11.10.2",
@@ -14022,12 +14106,6 @@
                 "tslib": "^2.3.0"
             }
         },
-        "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-            "dev": true
-        },
         "node_modules/@peculiar/json-schema": {
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
@@ -14055,12 +14133,6 @@
             "engines": {
                 "node": ">=10.12.0"
             }
-        },
-        "node_modules/@peculiar/webcrypto/node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-            "dev": true
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
@@ -15560,12 +15632,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/abort-controller/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/chunked-blob-reader": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.0.tgz",
@@ -15591,18 +15657,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/chunked-blob-reader-native/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/chunked-blob-reader/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/config-resolver": {
             "version": "4.4.4",
             "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.4.tgz",
@@ -15620,60 +15674,32 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/config-resolver/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/core": {
-            "version": "3.19.0",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.19.0.tgz",
-            "integrity": "sha512-Y9oHXpBcXQgYHOcAEmxjkDilUbSTkgKjoHYed3WaYUH8jngq8lPWDBSpjHblJ9uOgBdy5mh3pzebrScDdYr29w==",
+            "version": "3.31.1",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+            "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-serde": "^4.2.7",
-                "@smithy/protocol-http": "^5.3.6",
-                "@smithy/types": "^4.10.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.6",
-                "@smithy/util-stream": "^4.5.7",
-                "@smithy/util-utf8": "^4.2.0",
-                "@smithy/uuid": "^1.1.0",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/core/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.6.tgz",
-            "integrity": "sha512-xBmawExyTzOjbhzkZwg+vVm/khg28kG+rj2sbGlULjFd1jI70sv/cbpaR0Ev4Yfd6CpDUDRMe64cTqR//wAOyA==",
+            "version": "4.4.16",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+            "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.6",
-                "@smithy/property-provider": "^4.2.6",
-                "@smithy/types": "^4.10.0",
-                "@smithy/url-parser": "^4.2.6",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/eventstream-codec": {
             "version": "4.2.6",
@@ -15766,12 +15792,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/eventstream-codec/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/eventstream-serde-browser": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.6.tgz",
@@ -15786,12 +15806,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/eventstream-serde-browser/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/eventstream-serde-config-resolver": {
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.6.tgz",
@@ -15804,12 +15818,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/eventstream-serde-config-resolver/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/eventstream-serde-node": {
             "version": "4.2.6",
@@ -15825,12 +15833,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/eventstream-serde-node/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/eventstream-serde-universal": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.6.tgz",
@@ -15845,33 +15847,19 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/eventstream-serde-universal/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.7.tgz",
-            "integrity": "sha512-fcVap4QwqmzQwQK9QU3keeEpCzTjnP9NJ171vI7GnD7nbkAIcP9biZhDUx88uRH9BabSsQDS0unUps88uZvFIQ==",
+            "version": "5.6.13",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+            "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.6",
-                "@smithy/querystring-builder": "^4.2.6",
-                "@smithy/types": "^4.10.0",
-                "@smithy/util-base64": "^4.3.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/hash-blob-browser": {
             "version": "4.2.7",
@@ -15888,12 +15876,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/hash-blob-browser/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/hash-node": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.6.tgz",
@@ -15909,12 +15891,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/hash-node/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/hash-stream-node": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.6.tgz",
@@ -15929,12 +15905,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/hash-stream-node/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/invalid-dependency": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.6.tgz",
@@ -15948,12 +15918,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/invalid-dependency/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/is-array-buffer": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
@@ -15965,12 +15929,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/is-array-buffer/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/md5-js": {
             "version": "4.2.6",
@@ -15986,12 +15944,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/md5-js/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/middleware-content-length": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.6.tgz",
@@ -16005,12 +15957,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/middleware-content-length/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/middleware-endpoint": {
             "version": "4.4.0",
@@ -16030,12 +15976,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/middleware-retry": {
             "version": "4.4.16",
@@ -16057,12 +15997,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/middleware-retry/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/middleware-serde": {
             "version": "4.2.7",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.7.tgz",
@@ -16077,12 +16011,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/middleware-serde/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/middleware-stack": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.6.tgz",
@@ -16095,12 +16023,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/middleware-stack/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/node-config-provider": {
             "version": "4.3.6",
@@ -16117,33 +16039,19 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/node-config-provider/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.4.6",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-            "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+            "version": "4.9.13",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+            "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^4.2.6",
-                "@smithy/protocol-http": "^5.3.6",
-                "@smithy/querystring-builder": "^4.2.6",
-                "@smithy/types": "^4.10.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/node-http-handler/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/property-provider": {
             "version": "4.2.6",
@@ -16158,12 +16066,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/property-provider/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/protocol-http": {
             "version": "5.3.6",
             "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.6.tgz",
@@ -16177,32 +16079,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/protocol-http/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/querystring-builder": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-            "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.10.0",
-                "@smithy/util-uri-escape": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/querystring-builder/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/querystring-parser": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.6.tgz",
@@ -16215,12 +16091,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/querystring-parser/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/service-error-classification": {
             "version": "4.2.6",
@@ -16247,36 +16117,19 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.3.6",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.6.tgz",
-            "integrity": "sha512-P1TXDHuQMadTMTOBv4oElZMURU4uyEhxhHfn+qOc2iofW9Rd4sZtBGx58Lzk112rIGVEYZT8eUMK4NftpewpRA==",
+            "version": "5.6.12",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+            "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.2.0",
-                "@smithy/protocol-http": "^5.3.6",
-                "@smithy/types": "^4.10.0",
-                "@smithy/util-hex-encoding": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.6",
-                "@smithy/util-uri-escape": "^4.2.0",
-                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/signature-v4/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/smithy-client": {
             "version": "4.10.1",
@@ -16296,16 +16149,10 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/smithy-client/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/types": {
-            "version": "4.10.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-            "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+            "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -16313,12 +16160,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/types/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/url-parser": {
             "version": "4.2.6",
@@ -16334,12 +16175,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/url-parser/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/util-base64": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
@@ -16354,12 +16189,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/util-base64/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/util-body-length-browser": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
@@ -16372,12 +16201,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/util-body-length-node": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
@@ -16389,12 +16212,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/util-body-length-node/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/util-buffer-from": {
             "version": "4.2.0",
@@ -16409,12 +16226,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/util-buffer-from/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/util-config-provider": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
@@ -16426,12 +16237,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/util-config-provider/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
             "version": "4.3.15",
@@ -16447,12 +16252,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/util-defaults-mode-node": {
             "version": "4.2.18",
@@ -16472,12 +16271,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/util-endpoints": {
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.6.tgz",
@@ -16492,12 +16285,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/util-endpoints/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/util-hex-encoding": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
@@ -16509,12 +16296,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/util-middleware": {
             "version": "4.2.6",
@@ -16529,12 +16310,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/util-middleware/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/util-retry": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.6.tgz",
@@ -16548,12 +16323,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/util-retry/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/util-stream": {
             "version": "4.5.7",
@@ -16574,30 +16343,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/util-stream/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
-        "node_modules/@smithy/util-uri-escape": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-            "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-uri-escape/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/util-utf8": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
@@ -16610,12 +16355,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/util-utf8/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@smithy/util-waiter": {
             "version": "4.2.6",
@@ -16631,12 +16370,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/util-waiter/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "node_modules/@smithy/uuid": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
@@ -16648,12 +16381,6 @@
             "engines": {
                 "node": ">=18.0.0"
             }
-        },
-        "node_modules/@smithy/uuid/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
         },
         "node_modules/@surma/rollup-plugin-off-main-thread": {
             "version": "2.2.3",
@@ -17386,14 +17113,6 @@
             "dependencies": {
                 "tslib": "^2.4.0"
             }
-        },
-        "node_modules/@tybys/wasm-util/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "license": "0BSD",
-            "optional": true
         },
         "node_modules/@types/aria-query": {
             "version": "4.2.2",
@@ -23242,11 +22961,6 @@
             "peerDependencies": {
                 "react": ">=16.12.0"
             }
-        },
-        "node_modules/downshift/node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
@@ -34594,12 +34308,6 @@
                 "tslib": "^2.3.1"
             }
         },
-        "node_modules/pvtsutils/node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-            "dev": true
-        },
         "node_modules/pvutils": {
             "version": "1.0.17",
             "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
@@ -38722,9 +38430,10 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
         "node_modules/tss-react": {
             "version": "4.6.0",
@@ -39619,12 +39328,6 @@
                 "pvtsutils": "^1.2.0",
                 "tslib": "^2.3.1"
             }
-        },
-        "node_modules/webcrypto-core/node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-            "dev": true
         },
         "node_modules/webidl-conversions": {
             "version": "6.1.0",
@@ -40777,6 +40480,7 @@
                 "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
                 "@aws-sdk/client-s3": "^3.954.0",
                 "@aws-sdk/client-ses": "^3.946.0",
+                "@aws-sdk/client-ssm": "^3.1106.0",
                 "@aws-sdk/credential-provider-node": "^3.6.1",
                 "@aws-sdk/protocol-http": "^3.6.1",
                 "@aws-sdk/signature-v4": "^3.6.1",
@@ -42992,12 +42696,6 @@
                 }
             }
         },
-        "packages/lambda/node_modules/tslib": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
-        },
         "packages/lambda/node_modules/type-fest": {
             "version": "4.41.0",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -43621,11 +43319,6 @@
                         "@smithy/util-buffer-from": "^2.2.0",
                         "tslib": "^2.6.2"
                     }
-                },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -43709,11 +43402,6 @@
                         "@smithy/util-buffer-from": "^2.2.0",
                         "tslib": "^2.6.2"
                     }
-                },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -44565,12 +44253,6 @@
                         "tslib": "^2.3.1"
                     }
                 },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-                    "dev": true
-                },
                 "uuid": {
                     "version": "8.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -45301,11 +44983,6 @@
                         "tslib": "^2.3.1"
                     }
                 },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-                },
                 "uuid": {
                     "version": "8.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -45898,11 +45575,6 @@
                         "tslib": "^2.3.1"
                     }
                 },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-                },
                 "uuid": {
                     "version": "8.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -46450,11 +46122,6 @@
                         "@aws-sdk/util-buffer-from": "3.186.0",
                         "tslib": "^2.3.1"
                     }
-                },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -47109,11 +46776,216 @@
                         "@smithy/is-array-buffer": "^2.2.0",
                         "tslib": "^2.6.2"
                     }
+                }
+            }
+        },
+        "@aws-sdk/client-ssm": {
+            "version": "3.1106.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1106.0.tgz",
+            "integrity": "sha512-jPGMnYT+XtpXnnXzOBm9zBg+o4+vGQClj8TtDKZzX6sGFVcEunQEL1dZHn5iRy3z5vaGN+T7ch4zgI9A2WJkfA==",
+            "requires": {
+                "@aws-sdk/core": "^3.977.6",
+                "@aws-sdk/credential-provider-node": "^3.972.78",
+                "@aws-sdk/types": "^3.974.2",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
+                "@smithy/types": "^4.16.1",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@aws-sdk/core": {
+                    "version": "3.977.6",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+                    "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+                    "requires": {
+                        "@aws-sdk/types": "^3.974.2",
+                        "@aws-sdk/xml-builder": "^3.972.37",
+                        "@aws/lambda-invoke-store": "^0.3.0",
+                        "@smithy/core": "^3.31.1",
+                        "@smithy/signature-v4": "^5.6.12",
+                        "@smithy/types": "^4.16.1",
+                        "bowser": "^2.11.0",
+                        "tslib": "^2.6.2"
+                    }
                 },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+                "@aws-sdk/credential-provider-env": {
+                    "version": "3.972.67",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+                    "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+                    "requires": {
+                        "@aws-sdk/core": "^3.977.6",
+                        "@aws-sdk/types": "^3.974.2",
+                        "@smithy/core": "^3.31.1",
+                        "@smithy/types": "^4.16.1",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-http": {
+                    "version": "3.972.69",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+                    "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+                    "requires": {
+                        "@aws-sdk/core": "^3.977.6",
+                        "@aws-sdk/types": "^3.974.2",
+                        "@smithy/core": "^3.31.1",
+                        "@smithy/fetch-http-handler": "^5.6.13",
+                        "@smithy/node-http-handler": "^4.9.13",
+                        "@smithy/types": "^4.16.1",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-ini": {
+                    "version": "3.973.12",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+                    "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+                    "requires": {
+                        "@aws-sdk/core": "^3.977.6",
+                        "@aws-sdk/credential-provider-env": "^3.972.67",
+                        "@aws-sdk/credential-provider-http": "^3.972.69",
+                        "@aws-sdk/credential-provider-login": "^3.972.74",
+                        "@aws-sdk/credential-provider-process": "^3.972.67",
+                        "@aws-sdk/credential-provider-sso": "^3.973.11",
+                        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+                        "@aws-sdk/nested-clients": "^3.997.41",
+                        "@aws-sdk/types": "^3.974.2",
+                        "@smithy/core": "^3.31.1",
+                        "@smithy/credential-provider-imds": "^4.4.16",
+                        "@smithy/types": "^4.16.1",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-login": {
+                    "version": "3.972.74",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+                    "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
+                    "requires": {
+                        "@aws-sdk/core": "^3.977.6",
+                        "@aws-sdk/nested-clients": "^3.997.41",
+                        "@aws-sdk/types": "^3.974.2",
+                        "@smithy/core": "^3.31.1",
+                        "@smithy/types": "^4.16.1",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-node": {
+                    "version": "3.972.78",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+                    "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+                    "requires": {
+                        "@aws-sdk/credential-provider-env": "^3.972.67",
+                        "@aws-sdk/credential-provider-http": "^3.972.69",
+                        "@aws-sdk/credential-provider-ini": "^3.973.12",
+                        "@aws-sdk/credential-provider-process": "^3.972.67",
+                        "@aws-sdk/credential-provider-sso": "^3.973.11",
+                        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+                        "@aws-sdk/types": "^3.974.2",
+                        "@smithy/core": "^3.31.1",
+                        "@smithy/credential-provider-imds": "^4.4.16",
+                        "@smithy/types": "^4.16.1",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-process": {
+                    "version": "3.972.67",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+                    "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+                    "requires": {
+                        "@aws-sdk/core": "^3.977.6",
+                        "@aws-sdk/types": "^3.974.2",
+                        "@smithy/core": "^3.31.1",
+                        "@smithy/types": "^4.16.1",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-sso": {
+                    "version": "3.973.11",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+                    "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+                    "requires": {
+                        "@aws-sdk/core": "^3.977.6",
+                        "@aws-sdk/nested-clients": "^3.997.41",
+                        "@aws-sdk/token-providers": "3.1103.0",
+                        "@aws-sdk/types": "^3.974.2",
+                        "@smithy/core": "^3.31.1",
+                        "@smithy/types": "^4.16.1",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/credential-provider-web-identity": {
+                    "version": "3.972.73",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+                    "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+                    "requires": {
+                        "@aws-sdk/core": "^3.977.6",
+                        "@aws-sdk/nested-clients": "^3.997.41",
+                        "@aws-sdk/types": "^3.974.2",
+                        "@smithy/core": "^3.31.1",
+                        "@smithy/types": "^4.16.1",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/nested-clients": {
+                    "version": "3.997.41",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+                    "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+                    "requires": {
+                        "@aws-sdk/core": "^3.977.6",
+                        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+                        "@aws-sdk/types": "^3.974.2",
+                        "@smithy/core": "^3.31.1",
+                        "@smithy/fetch-http-handler": "^5.6.13",
+                        "@smithy/node-http-handler": "^4.9.13",
+                        "@smithy/types": "^4.16.1",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/signature-v4-multi-region": {
+                    "version": "3.996.43",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+                    "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+                    "requires": {
+                        "@aws-sdk/types": "^3.974.2",
+                        "@smithy/signature-v4": "^5.6.12",
+                        "@smithy/types": "^4.16.1",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/token-providers": {
+                    "version": "3.1103.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+                    "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+                    "requires": {
+                        "@aws-sdk/core": "^3.977.6",
+                        "@aws-sdk/nested-clients": "^3.997.41",
+                        "@aws-sdk/types": "^3.974.2",
+                        "@smithy/core": "^3.31.1",
+                        "@smithy/types": "^4.16.1",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/types": {
+                    "version": "3.974.2",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+                    "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+                    "requires": {
+                        "@smithy/types": "^4.16.1",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws-sdk/xml-builder": {
+                    "version": "3.972.37",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+                    "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+                    "requires": {
+                        "@smithy/types": "^4.16.1",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@aws/lambda-invoke-store": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+                    "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="
                 }
             }
         },
@@ -47576,11 +47448,6 @@
                         "@aws-sdk/util-buffer-from": "3.186.0",
                         "tslib": "^2.3.1"
                     }
-                },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -48137,11 +48004,6 @@
                     "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
                     "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
                 },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-                },
                 "uuid": {
                     "version": "8.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -48337,11 +48199,6 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
                     "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="
-                },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -48405,11 +48262,6 @@
                         "@smithy/types": "^4.9.0",
                         "tslib": "^2.6.2"
                     }
-                },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -48471,11 +48323,6 @@
                         "@smithy/types": "^4.9.0",
                         "tslib": "^2.6.2"
                     }
-                },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -48554,11 +48401,6 @@
                     "version": "3.186.0",
                     "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
                     "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ=="
-                },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
                 }
             }
         },
@@ -48585,11 +48427,6 @@
                     "version": "3.186.0",
                     "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
                     "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ=="
-                },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
                 }
             }
         },
@@ -48616,11 +48453,6 @@
                     "requires": {
                         "tslib": "^2.3.1"
                     }
-                },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
                 }
             }
         },
@@ -48638,11 +48470,6 @@
                     "version": "3.186.0",
                     "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
                     "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ=="
-                },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
                 }
             }
         },
@@ -48937,11 +48764,6 @@
                     "version": "3.186.0",
                     "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
                     "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ=="
-                },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
                 }
             }
         },
@@ -49084,11 +48906,6 @@
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
                     "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="
-                },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -49181,11 +48998,6 @@
                     "version": "3.186.0",
                     "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
                     "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ=="
-                },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
                 }
             }
         },
@@ -49317,11 +49129,6 @@
                     "requires": {
                         "tslib": "^2.3.1"
                     }
-                },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
                 }
             }
         },
@@ -49611,11 +49418,6 @@
                         "@smithy/is-array-buffer": "^2.2.0",
                         "tslib": "^2.6.2"
                     }
-                },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -49741,11 +49543,6 @@
                         "@smithy/types": "^4.9.0",
                         "tslib": "^2.6.2"
                     }
-                },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -49902,11 +49699,6 @@
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
                     "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="
-                },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -49949,11 +49741,6 @@
                         "@smithy/types": "^4.9.0",
                         "tslib": "^2.6.2"
                     }
-                },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -50095,13 +49882,6 @@
             "integrity": "sha512-71Qwu/PN02XsRLApyxG0EUy/NxWh/CXxtl2C7qY14t+KTiRapwbDkdJ1cMsqYqghYP4BwJoj1M+EFMQSSlkZQQ==",
             "requires": {
                 "tslib": "^2.3.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-                }
             }
         },
         "@aws-sdk/util-create-request": {
@@ -50146,11 +49926,6 @@
                     "version": "3.186.0",
                     "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
                     "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ=="
-                },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
                 }
             }
         },
@@ -50280,11 +50055,6 @@
                     "requires": {
                         "tslib": "^2.3.1"
                     }
-                },
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
                 }
             }
         },
@@ -50308,11 +50078,6 @@
                         "@smithy/types": "^4.9.0",
                         "tslib": "^2.6.2"
                     }
-                },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -50354,13 +50119,6 @@
             "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
             "requires": {
                 "tslib": "^2.3.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-                    "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-                }
             }
         },
         "@aws-sdk/util-middleware": {
@@ -50369,13 +50127,6 @@
             "integrity": "sha512-fddwDgXtnHyL9mEZ4s1tBBsKnVQHqTUmFbZKUUKPrg9CxOh0Y/zZxEa5Olg/8dS/LzM1tvg0ATkcyd4/kEHIhg==",
             "requires": {
                 "tslib": "^2.3.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-                }
             }
         },
         "@aws-sdk/util-uri-escape": {
@@ -52301,15 +52052,6 @@
             "requires": {
                 "@emnapi/wasi-threads": "1.1.0",
                 "tslib": "^2.4.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-                    "dev": true,
-                    "optional": true
-                }
             }
         },
         "@emnapi/runtime": {
@@ -52320,15 +52062,6 @@
             "optional": true,
             "requires": {
                 "tslib": "^2.4.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-                    "dev": true,
-                    "optional": true
-                }
             }
         },
         "@emnapi/wasi-threads": {
@@ -52339,15 +52072,6 @@
             "optional": true,
             "requires": {
                 "tslib": "^2.4.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-                    "dev": true,
-                    "optional": true
-                }
             }
         },
         "@emotion/babel-plugin": {
@@ -54172,14 +53896,6 @@
                 "asn1js": "^2.1.1",
                 "pvtsutils": "^1.2.1",
                 "tslib": "^2.3.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-                    "dev": true
-                }
             }
         },
         "@peculiar/json-schema": {
@@ -54202,14 +53918,6 @@
                 "pvtsutils": "^1.2.1",
                 "tslib": "^2.3.1",
                 "webcrypto-core": "^1.3.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-                    "dev": true
-                }
             }
         },
         "@pkgjs/parseargs": {
@@ -54240,6 +53948,7 @@
                 "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
                 "@aws-sdk/client-s3": "^3.954.0",
                 "@aws-sdk/client-ses": "^3.946.0",
+                "@aws-sdk/client-ssm": "^3.1106.0",
                 "@aws-sdk/credential-provider-node": "^3.6.1",
                 "@aws-sdk/protocol-http": "^3.6.1",
                 "@aws-sdk/signature-v4": "^3.6.1",
@@ -55855,11 +55564,6 @@
                         "yargs-parser": "^21.1.1"
                     }
                 },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                },
                 "type-fest": {
                     "version": "4.41.0",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -57111,13 +56815,6 @@
             "requires": {
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/chunked-blob-reader": {
@@ -57126,13 +56823,6 @@
             "integrity": "sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA==",
             "requires": {
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/chunked-blob-reader-native": {
@@ -57142,13 +56832,6 @@
             "requires": {
                 "@smithy/util-base64": "^4.3.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/config-resolver": {
@@ -57162,56 +56845,25 @@
                 "@smithy/util-endpoints": "^3.2.6",
                 "@smithy/util-middleware": "^4.2.6",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/core": {
-            "version": "3.19.0",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.19.0.tgz",
-            "integrity": "sha512-Y9oHXpBcXQgYHOcAEmxjkDilUbSTkgKjoHYed3WaYUH8jngq8lPWDBSpjHblJ9uOgBdy5mh3pzebrScDdYr29w==",
+            "version": "3.31.1",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+            "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
             "requires": {
-                "@smithy/middleware-serde": "^4.2.7",
-                "@smithy/protocol-http": "^5.3.6",
-                "@smithy/types": "^4.10.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.6",
-                "@smithy/util-stream": "^4.5.7",
-                "@smithy/util-utf8": "^4.2.0",
-                "@smithy/uuid": "^1.1.0",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/credential-provider-imds": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.6.tgz",
-            "integrity": "sha512-xBmawExyTzOjbhzkZwg+vVm/khg28kG+rj2sbGlULjFd1jI70sv/cbpaR0Ev4Yfd6CpDUDRMe64cTqR//wAOyA==",
+            "version": "4.4.16",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+            "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
             "requires": {
-                "@smithy/node-config-provider": "^4.3.6",
-                "@smithy/property-provider": "^4.2.6",
-                "@smithy/types": "^4.10.0",
-                "@smithy/url-parser": "^4.2.6",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/eventstream-codec": {
@@ -57279,11 +56931,6 @@
                         "@smithy/util-buffer-from": "^2.2.0",
                         "tslib": "^2.6.2"
                     }
-                },
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
                 }
             }
         },
@@ -57295,13 +56942,6 @@
                 "@smithy/eventstream-serde-universal": "^4.2.6",
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/eventstream-serde-config-resolver": {
@@ -57311,13 +56951,6 @@
             "requires": {
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/eventstream-serde-node": {
@@ -57328,13 +56961,6 @@
                 "@smithy/eventstream-serde-universal": "^4.2.6",
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/eventstream-serde-universal": {
@@ -57345,32 +56971,16 @@
                 "@smithy/eventstream-codec": "^4.2.6",
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/fetch-http-handler": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.7.tgz",
-            "integrity": "sha512-fcVap4QwqmzQwQK9QU3keeEpCzTjnP9NJ171vI7GnD7nbkAIcP9biZhDUx88uRH9BabSsQDS0unUps88uZvFIQ==",
+            "version": "5.6.13",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+            "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
             "requires": {
-                "@smithy/protocol-http": "^5.3.6",
-                "@smithy/querystring-builder": "^4.2.6",
-                "@smithy/types": "^4.10.0",
-                "@smithy/util-base64": "^4.3.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/hash-blob-browser": {
@@ -57382,13 +56992,6 @@
                 "@smithy/chunked-blob-reader-native": "^4.2.1",
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/hash-node": {
@@ -57400,13 +57003,6 @@
                 "@smithy/util-buffer-from": "^4.2.0",
                 "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/hash-stream-node": {
@@ -57417,13 +57013,6 @@
                 "@smithy/types": "^4.10.0",
                 "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/invalid-dependency": {
@@ -57433,13 +57022,6 @@
             "requires": {
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/is-array-buffer": {
@@ -57448,13 +57030,6 @@
             "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
             "requires": {
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/md5-js": {
@@ -57465,13 +57040,6 @@
                 "@smithy/types": "^4.10.0",
                 "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/middleware-content-length": {
@@ -57482,13 +57050,6 @@
                 "@smithy/protocol-http": "^5.3.6",
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/middleware-endpoint": {
@@ -57504,13 +57065,6 @@
                 "@smithy/url-parser": "^4.2.6",
                 "@smithy/util-middleware": "^4.2.6",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/middleware-retry": {
@@ -57527,13 +57081,6 @@
                 "@smithy/util-retry": "^4.2.6",
                 "@smithy/uuid": "^1.1.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/middleware-serde": {
@@ -57544,13 +57091,6 @@
                 "@smithy/protocol-http": "^5.3.6",
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/middleware-stack": {
@@ -57560,13 +57100,6 @@
             "requires": {
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/node-config-provider": {
@@ -57578,32 +57111,16 @@
                 "@smithy/shared-ini-file-loader": "^4.4.1",
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/node-http-handler": {
-            "version": "4.4.6",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.6.tgz",
-            "integrity": "sha512-Gsb9jf4ido5BhPfani4ggyrKDd3ZK+vTFWmUaZeFg5G3E5nhFmqiTzAIbHqmPs1sARuJawDiGMGR/nY+Gw6+aQ==",
+            "version": "4.9.13",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+            "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
             "requires": {
-                "@smithy/abort-controller": "^4.2.6",
-                "@smithy/protocol-http": "^5.3.6",
-                "@smithy/querystring-builder": "^4.2.6",
-                "@smithy/types": "^4.10.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/property-provider": {
@@ -57613,13 +57130,6 @@
             "requires": {
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/protocol-http": {
@@ -57629,30 +57139,6 @@
             "requires": {
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
-            }
-        },
-        "@smithy/querystring-builder": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.6.tgz",
-            "integrity": "sha512-MeM9fTAiD3HvoInK/aA8mgJaKQDvm8N0dKy6EiFaCfgpovQr4CaOkJC28XqlSRABM+sHdSQXbC8NZ0DShBMHqg==",
-            "requires": {
-                "@smithy/types": "^4.10.0",
-                "@smithy/util-uri-escape": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/querystring-parser": {
@@ -57662,13 +57148,6 @@
             "requires": {
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/service-error-classification": {
@@ -57686,35 +57165,16 @@
             "requires": {
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/signature-v4": {
-            "version": "5.3.6",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.6.tgz",
-            "integrity": "sha512-P1TXDHuQMadTMTOBv4oElZMURU4uyEhxhHfn+qOc2iofW9Rd4sZtBGx58Lzk112rIGVEYZT8eUMK4NftpewpRA==",
+            "version": "5.6.12",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+            "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
             "requires": {
-                "@smithy/is-array-buffer": "^4.2.0",
-                "@smithy/protocol-http": "^5.3.6",
-                "@smithy/types": "^4.10.0",
-                "@smithy/util-hex-encoding": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.6",
-                "@smithy/util-uri-escape": "^4.2.0",
-                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/core": "^3.31.1",
+                "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/smithy-client": {
@@ -57729,28 +57189,14 @@
                 "@smithy/types": "^4.10.0",
                 "@smithy/util-stream": "^4.5.7",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/types": {
-            "version": "4.10.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-            "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+            "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
             "requires": {
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/url-parser": {
@@ -57761,13 +57207,6 @@
                 "@smithy/querystring-parser": "^4.2.6",
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-base64": {
@@ -57778,13 +57217,6 @@
                 "@smithy/util-buffer-from": "^4.2.0",
                 "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-body-length-browser": {
@@ -57793,13 +57225,6 @@
             "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
             "requires": {
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-body-length-node": {
@@ -57808,13 +57233,6 @@
             "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
             "requires": {
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-buffer-from": {
@@ -57824,13 +57242,6 @@
             "requires": {
                 "@smithy/is-array-buffer": "^4.2.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-config-provider": {
@@ -57839,13 +57250,6 @@
             "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
             "requires": {
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-defaults-mode-browser": {
@@ -57857,13 +57261,6 @@
                 "@smithy/smithy-client": "^4.10.1",
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-defaults-mode-node": {
@@ -57878,13 +57275,6 @@
                 "@smithy/smithy-client": "^4.10.1",
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-endpoints": {
@@ -57895,13 +57285,6 @@
                 "@smithy/node-config-provider": "^4.3.6",
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-hex-encoding": {
@@ -57910,13 +57293,6 @@
             "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
             "requires": {
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-middleware": {
@@ -57926,13 +57302,6 @@
             "requires": {
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-retry": {
@@ -57943,13 +57312,6 @@
                 "@smithy/service-error-classification": "^4.2.6",
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-stream": {
@@ -57965,28 +57327,6 @@
                 "@smithy/util-hex-encoding": "^4.2.0",
                 "@smithy/util-utf8": "^4.2.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
-            }
-        },
-        "@smithy/util-uri-escape": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-            "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
-            "requires": {
-                "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-utf8": {
@@ -57996,13 +57336,6 @@
             "requires": {
                 "@smithy/util-buffer-from": "^4.2.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/util-waiter": {
@@ -58013,13 +57346,6 @@
                 "@smithy/abort-controller": "^4.2.6",
                 "@smithy/types": "^4.10.0",
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@smithy/uuid": {
@@ -58028,13 +57354,6 @@
             "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
             "requires": {
                 "tslib": "^2.6.2"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-                }
             }
         },
         "@surma/rollup-plugin-off-main-thread": {
@@ -58533,15 +57852,6 @@
             "optional": true,
             "requires": {
                 "tslib": "^2.4.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-                    "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-                    "dev": true,
-                    "optional": true
-                }
             }
         },
         "@types/aria-query": {
@@ -62953,13 +62263,6 @@
                 "prop-types": "^15.7.2",
                 "react-is": "^17.0.2",
                 "tslib": "^2.3.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-                }
             }
         },
         "dunder-proto": {
@@ -71230,14 +70533,6 @@
             "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-                    "dev": true
-                }
             }
         },
         "pvutils": {
@@ -74320,9 +73615,9 @@
             }
         },
         "tslib": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "tss-react": {
             "version": "4.6.0",
@@ -74980,14 +74275,6 @@
                 "asn1js": "^2.1.1",
                 "pvtsutils": "^1.2.0",
                 "tslib": "^2.3.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-                    "dev": true
-                }
             }
         },
         "webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40474,7 +40474,7 @@
         },
         "packages/lambda": {
             "name": "@platelet-app/lambda",
-            "version": "1.1.13",
+            "version": "1.1.19",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-js": "^1.0.0-alpha.0",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -29,6 +29,7 @@
         "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
         "@aws-sdk/client-s3": "^3.954.0",
         "@aws-sdk/client-ses": "^3.946.0",
+        "@aws-sdk/client-ssm": "^3.1106.0",
         "@aws-sdk/credential-provider-node": "^3.6.1",
         "@aws-sdk/protocol-http": "^3.6.1",
         "@aws-sdk/signature-v4": "^3.6.1",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@platelet-app/lambda",
-    "version": "1.1.13",
+    "version": "1.1.19",
     "description": "Lambda functionality for the platelet.app project",
     "homepage": "https://github.com/platelet-app/platelet#readme",
     "bugs": {

--- a/packages/lambda/src/lambda/generateSecurePassword.test.ts
+++ b/packages/lambda/src/lambda/generateSecurePassword.test.ts
@@ -1,0 +1,60 @@
+import { generateSecurePassword } from "./generateSecurePassword.js";
+
+const UPPER = /[ABCDEFGHJKLMNPQRSTUVWXYZ]/;
+const LOWER = /[abcdefghijkmnopqrstuvwxyz]/;
+const DIGIT = /[23456789]/;
+const SYMBOL = /[!@#$%^&*()\-_=+]/;
+const ALLOWED =
+    /^[ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%^&*()\-_=+]+$/;
+
+describe("generateSecurePassword", () => {
+    it("returns the default length of 16", () => {
+        expect(generateSecurePassword()).toHaveLength(16);
+    });
+
+    it("respects a custom length", () => {
+        expect(generateSecurePassword(24)).toHaveLength(24);
+        expect(generateSecurePassword(8)).toHaveLength(8);
+    });
+
+    it("contains at least one of each character class", () => {
+        // Run many times since a single pass could luck out even with a broken shuffle
+        for (let i = 0; i < 200; i++) {
+            const pw = generateSecurePassword();
+            expect(pw).toMatch(UPPER);
+            expect(pw).toMatch(LOWER);
+            expect(pw).toMatch(DIGIT);
+            expect(pw).toMatch(SYMBOL);
+        }
+    });
+
+    it("only uses characters from the allowed alphabet", () => {
+        for (let i = 0; i < 200; i++) {
+            expect(generateSecurePassword()).toMatch(ALLOWED);
+        }
+    });
+
+    it("excludes ambiguous characters", () => {
+        for (let i = 0; i < 200; i++) {
+            expect(generateSecurePassword()).not.toMatch(/[Il1O0]/);
+        }
+    });
+
+    it("does not produce duplicate passwords", () => {
+        const passwords = new Set(
+            Array.from({ length: 1000 }, () => generateSecurePassword())
+        );
+        expect(passwords.size).toBe(1000);
+    });
+
+    it("does not always place character classes in the same positions", () => {
+        // Catches a missing/broken shuffle: without it, index 0 is always uppercase
+        const firstChars = new Set(
+            Array.from({ length: 100 }, () => generateSecurePassword()[0])
+        );
+        const classes = [UPPER, LOWER, DIGIT, SYMBOL].filter((re) =>
+            [...firstChars].some((c) => re.test(c))
+        );
+        expect(classes.length).toBeGreaterThan(1);
+    });
+});

--- a/packages/lambda/src/lambda/generateSecurePassword.ts
+++ b/packages/lambda/src/lambda/generateSecurePassword.ts
@@ -1,0 +1,29 @@
+import { randomInt } from "crypto";
+
+export const generateSecurePassword = (length = 16) => {
+    const upper = "ABCDEFGHJKLMNPQRSTUVWXYZ";
+    const lower = "abcdefghijkmnopqrstuvwxyz";
+    const digits = "23456789";
+    const symbols = "!@#$%^&*()-_=+";
+    const all = upper + lower + digits + symbols;
+
+    // Guarantee at least one of each class (Cognito's default policy needs all four)
+    const chars = [
+        upper[randomInt(upper.length)],
+        lower[randomInt(lower.length)],
+        digits[randomInt(digits.length)],
+        symbols[randomInt(symbols.length)],
+    ];
+
+    for (let i = chars.length; i < length; i++) {
+        chars.push(all[randomInt(all.length)]);
+    }
+
+    // Shuffle so the guaranteed characters aren't always at the start
+    for (let i = chars.length - 1; i > 0; i--) {
+        const j = randomInt(i + 1);
+        [chars[i], chars[j]] = [chars[j], chars[i]];
+    }
+
+    return chars.join("");
+};

--- a/packages/lambda/src/lambda/getEmailSSMParams.ts
+++ b/packages/lambda/src/lambda/getEmailSSMParams.ts
@@ -1,0 +1,35 @@
+import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
+
+const client = new SSMClient();
+
+const getParam = async (paramName: string) => {
+    const params = {
+        Name: paramName,
+    };
+    const command = new GetParameterCommand(params);
+    try {
+        const response = await client.send(command);
+        // The value is nested under Parameter.Value
+        return response.Parameter?.Value;
+    } catch (error) {
+        if (error.name === "ParameterNotFound") {
+            console.error(`Parameter not found: ${paramName}`);
+            return undefined;
+        }
+        console.error("Error retrieving SSM parameter:", error);
+        throw error;
+    }
+};
+export const getEmailSSMParams = async () => {
+    const fromEmailParameterName = `/platelet-supporting-cdk/${process.env.ENV}/FromEmail`;
+    const domainParameterName = `/platelet-supporting-cdk/${process.env.ENV}/DomainName`;
+    const fromEmail = await getParam(fromEmailParameterName);
+    const domainName = await getParam(domainParameterName);
+    if (!fromEmail) {
+        throw new Error(`Missing SSM parameter: ${fromEmailParameterName}`);
+    }
+    if (!domainName) {
+        throw new Error(`Missing SSM parameter: ${domainParameterName}`);
+    }
+    return { fromEmail, domainName };
+};

--- a/packages/lambda/src/lambda/index.ts
+++ b/packages/lambda/src/lambda/index.ts
@@ -2,3 +2,5 @@ export * from "./appSyncOperations.js";
 export * from "./customErrors.js";
 export { getUserProfilePictures } from "./getUserProfilePictures.js";
 export { sendPlateletEmail } from "./sendPlateletEmail.js";
+export { generateSecurePassword } from "./generateSecurePassword.js";
+export { sendTenantWelcomeEmail } from "./sendTenantWelcomeEmail.js";

--- a/packages/lambda/src/lambda/sendTenantWelcomeEmail.ts
+++ b/packages/lambda/src/lambda/sendTenantWelcomeEmail.ts
@@ -1,0 +1,64 @@
+import { SendEmailCommand } from "@aws-sdk/client-ses";
+import { sesClient } from "./libs/sesClient.js";
+import { getEmailSSMParams } from "./getEmailSSMParams.js";
+
+export const sendTenantWelcomeEmail = async (
+    emailAddress: string,
+    recipientName: string,
+    password: string
+) => {
+    const { fromEmail, domainName } = await getEmailSSMParams();
+    const params = {
+        Destination: {
+            ToAddresses: [emailAddress],
+        },
+        Message: {
+            Body: {
+                Html: {
+                    Charset: "UTF-8",
+                    Data: `
+                    <p>
+                        Welcome to https://${domainName}, ${recipientName}!
+                    </p>
+                    <p>
+                        Your account has been created. You can now start adding users to your team.
+                    </p>
+                    <p>
+                        You will be asked to change your password on first log in.
+                    </p>
+                    <p>
+                        <b>Username:</b> ${emailAddress}
+                    </p>
+                    <p>
+                        <b>Password:</b> ${password}
+                    </p>
+                    <p>
+                        <b>This temporary password will expire in one week.</b>
+                    </p>
+                    <p>
+                        Thank you.
+                    </p>
+                    `,
+                },
+                Text: {
+                    Charset: "UTF-8",
+                    Data: `Welcome to https://${domainName}, ${recipientName}!
+                    Your account has been created. You can now start adding users to your team.
+                    You will be asked to change your password on first log in.
+                    Username: ${emailAddress}
+                    Password: ${password}
+                    Thank you.`,
+                },
+            },
+            Subject: {
+                Charset: "UTF-8",
+                Data: "Welcome to Platelet!",
+            },
+        },
+        Source: fromEmail,
+        ReplyToAddresses: [fromEmail],
+        ReturnPath: fromEmail,
+    };
+    const sendEmailCommand = new SendEmailCommand(params);
+    return await sesClient.send(sendEmailCommand);
+};


### PR DESCRIPTION
Adds a register tenant lambda function to the supporting CDK. This function can be run manually from the AWS console to register a new tenant.

Should eventually replace the registerTenant mutation.